### PR TITLE
allow passing nacl secret non-interactively...

### DIFF
--- a/Jumpscale/data/nacl/NACL.py
+++ b/Jumpscale/data/nacl/NACL.py
@@ -19,18 +19,17 @@ class NACL(j.application.JSBaseClass):
     def __init__(self, name, privkey=None, secret=None, reset=False, interactive=True):
         while True:
             try:
-                self._init__(name=name, privkey=privkey, secret=secret, reset=reset, interactive=interactive)
+                self.init(name=name, privkey=privkey, secret=secret, reset=reset, interactive=interactive)
                 break
             except nacl.exceptions.CryptoError as e:
-                raise
                 print(e)
                 self._log_warning("ERROR in decrypting")
                 secret = j.tools.console.askPassword("issue in decrypting the private key, try other secret")
 
     def reset(self, privkey=None, secret=None):
-        self._init__(name=self.name, privkey=privkey, secret=secret, reset=True, interactive=True)
+        self.init(name=self.name, privkey=privkey, secret=secret, reset=True, interactive=True)
 
-    def _init__(self, name, privkey=None, secret=None, reset=False, interactive=True):
+    def init(self, name, privkey=None, secret=None, reset=False, interactive=True):
         """
         :param if secret given will be used in nacl
         """
@@ -50,7 +49,7 @@ class NACL(j.application.JSBaseClass):
 
         self._box = nacl.secret.SecretBox(secret)  # used to decrypt the private key
 
-        self.__init()
+        self.clear_keys()
 
         self.path_privatekey = "%s/%s.priv" % (self.path, self.name)
         if reset:
@@ -64,12 +63,11 @@ class NACL(j.application.JSBaseClass):
                     '{RED}a private key is generated for you, please store the following key secret in a safe place:{RESET}')
                 print('{BLUE}%s{RESET}' % self.words)
 
-        self.__init()
+        self.clear_keys()
 
         self.words  # will check that the private key is in line with secret used
 
-    def __init(self):
-
+    def clear_keys(self):
         self._privkey = ""
         self._pubkey = ""
         self._signingkey = ""

--- a/Jumpscale/data/nacl/NACL.py
+++ b/Jumpscale/data/nacl/NACL.py
@@ -1,3 +1,4 @@
+import os
 from Jumpscale import j
 from nacl.public import PrivateKey, SealedBox
 import nacl.signing
@@ -11,53 +12,87 @@ import binascii
 from nacl.exceptions import BadSignatureError
 import sys
 JSBASE = j.application.JSBaseClass
+print = j.tools.console.echo
 
 
 class NACL(j.application.JSBaseClass):
-    def __init__(self, name,privkey=None,secret=None,reset=False,interactive=True):
-
+    def __init__(self, name, privkey=None, secret=None, reset=False, interactive=True):
         while True:
             try:
-                self._init__(name=name,privkey=privkey,secret=secret,reset=reset,interactive=interactive)
+                self._init__(name=name, privkey=privkey, secret=secret, reset=reset, interactive=interactive)
                 break
             except nacl.exceptions.CryptoError as e:
+                raise
                 print(e)
                 self._log_warning("ERROR in decrypting")
                 secret = j.tools.console.askPassword("issue in decrypting the private key, try other secret")
 
-    def reset(self,privkey=None,secret=None):
-        self._init__(name=self.name,privkey=privkey,secret=secret,reset=True,interactive=True)
+    def reset(self, privkey=None, secret=None):
+        self._init__(name=self.name, privkey=privkey, secret=secret, reset=True, interactive=True)
 
-    def _init__(self, name,privkey=None,secret=None,reset=False,interactive=True):
+    def _init__(self, name, privkey=None, secret=None, reset=False, interactive=True):
         """
         :param if secret given will be used in nacl
         """
         JSBASE.__init__(self)
 
         self.name = name
+        self.interactive = interactive #  should remove interactive completely
 
         self.path = j.core.tools.text_replace("{DIR_CFG}/nacl")
         j.sal.fs.createDir(self.path)
         self._log_debug("NACL uses path:'%s'" % self.path)
 
-        path_encryptor_for_secret="{DIR_VAR}/myprocess_%s.log"%name
+        if not secret:
+            secret = self.get_secret_from_redis(reset=reset)
+        else:
+            secret = self._hash(secret)
+
+        self._box = nacl.secret.SecretBox(secret)  # used to decrypt the private key
+
+        self.__init()
+
+        self.path_privatekey = "%s/%s.priv" % (self.path, self.name)
+        if reset:
+            j.sal.fs.remove(self.path_privatekey)
+        if not j.sal.fs.exists(self.path_privatekey):
+            if interactive:
+                self.generate_interactive()
+            else:
+                self._keys_generate()
+                print(
+                    '{RED}a private key is generated for you, please store the following key secret in a safe place:{RESET}')
+                print('{BLUE}%s{RESET}' % self.words)
+
+        self.__init()
+
+        self.words  # will check that the private key is in line with secret used
+
+    def __init(self):
+
+        self._privkey = ""
+        self._pubkey = ""
+        self._signingkey = ""
+        self._signingkey_pub = ""
+
+    def get_secret_from_redis(self, reset=False):
+        path_encryptor_for_secret = "{DIR_VAR}/myprocess_%s.log" % self.name
         if reset:
             j.sal.fs.remove(path_encryptor_for_secret)
         if not j.sal.fs.exists(path_encryptor_for_secret):
             key = nacl.utils.random(nacl.secret.SecretBox.KEY_SIZE)
-            j.sal.fs.writeFile(path_encryptor_for_secret,key)
+            j.sal.fs.writeFile(path_encryptor_for_secret, key)
         else:
-            key = j.sal.fs.readFile(path_encryptor_for_secret,binary=True)
-        sb=nacl.secret.SecretBox(key)
-        redis_key="secret_%s"%name
-
-
-        if reset:
-            j.core.db.delete(redis_key)
+            key = j.sal.fs.readFile(path_encryptor_for_secret, binary=True)
+        sb = nacl.secret.SecretBox(key)
 
         # TODO: this should be placed in the correct location
         if not j.core.db:
             j.core._db = j.clients.redis.core_get()
+
+        redis_key = "secret_%s" % self.name
+        if reset:
+            j.core.db.delete(redis_key)
 
         r = j.core.db.get(redis_key)
         if r:
@@ -67,80 +102,56 @@ class NACL(j.application.JSBaseClass):
                 r = None
 
         if r is None:
+            if self.interactive:
+                secret = j.tools.console.askPassword(
+                    "Provide a strong secret which will be used to encrypt/decrypt your private key")
+                secret = secret.strip()
             if not secret:
-                secret = j.tools.console.askPassword("Provide a strong secret which will be used to encrypt/decrypt your private key")
-                if secret.strip() in [""]:
-                    raise RuntimeError("Secret cannot be empty")
-                secret = self._hash(secret)
-            r = sb.encrypt(secret)
-            j.core.db.set(redis_key,r)
+                raise RuntimeError("Secret cannot be empty")
+            r = sb.encrypt(self._hash(secret))
+            j.core.db.set(redis_key, r)
 
         r = j.core.db.get(redis_key)
-        secret = sb.decrypt(r) #this to doublecheck
+        secret = sb.decrypt(r)  # this to doublecheck
+        return secret
 
-        self._box = nacl.secret.SecretBox(secret)  #used to decrypt the private key
-
-        self.__init()
-
-        print = j.tools.console.echo
-
-        self.path_privatekey = "%s/%s.priv" % (self.path, self.name)
-        if reset:
-            j.sal.fs.remove(self.path_privatekey)
-        if not j.sal.fs.exists(self.path_privatekey):
-            if interactive:
-                msg = """
-                There is no private key on your system yet.
-                We will generate one for you or you can provide words of your secret key.
-                """
-                if j.tools.console.askYesNo("Ok to generate private key (Y or 1 for yes, otherwise provide words)?"):
-                    print("\nWe have generated a private key for you.")
-                    print("\nThe private key:\n\n")
-                    self._keys_generate()
-                    j.tools.console.echo("{RED}")
-                    print("{BLUE}"+self.words+"{RESET}\n")
-                    print("\n{RED}ITS IMPORTANT TO STORE THIS KEY IN A SAFE PLACE{RESET}")
-                    if not j.tools.console.askYesNo("Did you write the words down and store them in safe place?"):
-                        j.sal.fs.remove(self.path_privatekey)
-                        print("WE HAVE REMOVED THE KEY, need to restart this procedure.")
-                        sys.exit(1)
-                else:
-                    words = j.tools.console.askString("Provide words of private key")
-                    self._keys_generate(words=words)
-                    assert self.words == words
-
-            j.tools.console.clear_screen()
-
-            word3=self.words.split(" ")[2]
-
-            word3_to_check = j.tools.console.askString("give the 3e word of the private key string")
-
-            if not word3 == word3_to_check:
-                print ("the control word was not correct, please restart the procedure.")
+    def generate_interactive(self):
+        msg = """
+        There is no private key on your system yet.
+        We will generate one for you or you can provide words of your secret key.
+        """
+        if j.tools.console.askYesNo("Ok to generate private key (Y or 1 for yes, otherwise provide words)?"):
+            print("\nWe have generated a private key for you.")
+            print("\nThe private key:\n\n")
+            self._keys_generate()
+            j.tools.console.echo("{RED}")
+            print("{BLUE}"+self.words+"{RESET}\n")
+            print("\n{RED}ITS IMPORTANT TO STORE THIS KEY IN A SAFE PLACE{RESET}")
+            if not j.tools.console.askYesNo("Did you write the words down and store them in safe place?"):
+                j.sal.fs.remove(self.path_privatekey)
+                print("WE HAVE REMOVED THE KEY, need to restart this procedure.")
                 sys.exit(1)
+        else:
+            words = j.tools.console.askString("Provide words of private key")
+            self._keys_generate(words=words)
+            assert self.words == words
 
-        self.__init()
+        j.tools.console.clear_screen()
 
+        word3 = self.words.split(" ")[2]
 
-        self.words  #will check that the private key is in line with secret used
+        word3_to_check = j.tools.console.askString("give the 3e word of the private key string")
 
+        if not word3 == word3_to_check:
+            print("the control word was not correct, please restart the procedure.")
+            sys.exit(1)
 
-    def __init(self):
-
-        self._privkey = ""
-        self._pubkey = ""
-        self._signingkey = ""
-        self._signingkey_pub = ""
-
-
-
-    def _hash(self,data):
+    def _hash(self, data):
         m = hashlib.sha256()
         if not j.data.types.bytes.check(data):
             data = data.encode()
         m.update(data)
         return m.digest()
-
 
     @property
     def privkey(self):
@@ -201,7 +212,7 @@ class NACL(j.application.JSBaseClass):
         m.update(self.tobytes(data))
         return m.digest()[0:8]
 
-    def ssh_hash(self,data):
+    def ssh_hash(self, data):
         """
         uses sshagent to sign the payload & then hash result with md5
         :return:
@@ -211,7 +222,7 @@ class NACL(j.application.JSBaseClass):
         data2 = self.sign_with_ssh_key(data)
         return j.data.hash.md5_string(data2)
 
-    def encryptSymmetric(self, data, secret=b"", hex=False, salt=""):
+    def encryptSymmetric(self, data, hex=False, salt=""):
         box = self._box
         if salt == "":
             salt = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
@@ -250,7 +261,7 @@ class NACL(j.application.JSBaseClass):
             data = self.hex_to_bin(data)
         return unseal_box.decrypt(data)
 
-    def _keys_generate(self,words=None):
+    def _keys_generate(self, words=None):
         """
         Generate private key (strong) & store in chosen path &
         will load in this class
@@ -299,7 +310,7 @@ class NACL(j.application.JSBaseClass):
             this can be used to verify data against your own sshagent
             to make sure data has not been tampered with
 
-            this signature is then stored with e.g. data and you 
+            this signature is then stored with e.g. data and you
             can verify against your own ssh-agent if the data was
             tampered with
         """
@@ -325,6 +336,6 @@ class NACL(j.application.JSBaseClass):
         return content
 
     def __str__(self):
-        return "nacl:%s"%self.name
+        return "nacl:%s" % self.name
 
     __repr__ = __str__

--- a/Jumpscale/data/nacl/NACLFactory.py
+++ b/Jumpscale/data/nacl/NACLFactory.py
@@ -1,13 +1,10 @@
-from Jumpscale import j
-
-from .NACL import NACL
-import nacl.secret
-import nacl.utils
-import base64
-import hashlib
-from nacl.public import PrivateKey, SealedBox
+import os
 import fakeredis
+from Jumpscale import j
+from .NACL import NACL
+
 JSBASE = j.application.JSBaseClass
+
 
 class NACLFactory(j.application.JSBaseClass):
 
@@ -16,11 +13,11 @@ class NACLFactory(j.application.JSBaseClass):
         self.__jslocation__ = "j.data.nacl"
         self._default = None
 
-        #check there is core redis
-        if isinstance(j.core.db,fakeredis.FakeStrictRedis):
+        # check there is core redis
+        if isinstance(j.core.db, fakeredis.FakeStrictRedis):
             j.clients.redis.core_get()
 
-    def reset(self,name="default",privkey=None,secret=None,interactive=True):
+    def reset(self, name="default", privkey=None, secret=None, interactive=True):
         """
         removes the default private key & secret, be careful this will make your local data non accessible
         unless if you have your secret and key
@@ -28,20 +25,22 @@ class NACLFactory(j.application.JSBaseClass):
         """
         msg = """
         removes your private key & secret, be careful this will make your local data non accessible
-        unless if you have your secret and key        
+        unless if you have your secret and key
         """
         if interactive:
             print(j.core.text.strip(msg))
-            if not j.tools.console.askYesNo("Are you sure you want to erase your private key & secret for %s"%name):
+            if not j.tools.console.askYesNo("Are you sure you want to erase your private key & secret for %s" % name):
                 return
 
-        NACL(name, privkey=privkey,secret=secret,reset=True,interactive=interactive)
+        NACL(name, privkey=privkey, secret=secret, reset=True, interactive=interactive)
 
-
-    def get(self, name="default",privkey=None,secret=None):
+    def get(self, name="default", privkey=None, secret=None):
         """
         """
-        return NACL(name, privkey=privkey,secret=secret)
+        if not secret:
+            secret = os.environ.get('NACL_SECRET')
+        interactive = not bool(secret)
+        return NACL(name, privkey=privkey, secret=secret, interactive=interactive)
 
     @property
     def default(self):
@@ -49,227 +48,11 @@ class NACLFactory(j.application.JSBaseClass):
             self._default = self.get()
         return self._default
 
-    # @property
-    # def words(self):
-    #     """
-    #     default words which are securely stored on your filesystem
-    #     js_shell 'print(j.data.nacl.default.words)'
-    #     """
-    #     return self.default.words
-
-    # def remember(self):
-    #     """
-    #     will start redis core, this will make sure that the secret & words
-    #     are remembered for 1h
-    #
-    #     js_shell 'j.data.nacl.remember()'
-    #
-    #     """
-    #     j.clients.redis.core_get()
-
-    # def _remember_get(self, secret, words):
-    #
-    #     if "fake" not in str(j.core.db):
-    #         if j.core.db.exists("nacl.meta"):
-    #             data = j.core.db.get("nacl.meta")
-    #             data2 = self.default.decryptSymmetric(data)
-    #             data3 = j.data.serializers.json.loads(data2)
-    #
-    #             if "secret" in data3 and not secret:
-    #                 secret = data3["secret"]
-    #
-    #             if "words" in data3 and not words:
-    #                 words = data3["words"]
-
-        # return secret, words
-
-    # def _remember_set(self, secret, words):
-    #     if "fake" not in str(j.core.db):
-    #         data = {}
-    #         data["secret"] = secret
-    #         data["words"] = words
-    #         data2 = j.data.serializers.json.dumps(data)
-    #         data3 = self.default.encryptSymmetric(data2)
-    #         self._log_debug("remember secret,words")
-    #         j.core.db.set("nacl.meta", data3, ex=3600)
-    #
-    # def encrypt(self, secret="", message="", words="", interactive=False):
-    #     """
-    #     secret is any size key
-    #     words are bip39 words e.g. see https://iancoleman.io/bip39/#english
-    #
-    #     if words not given then will take from the default nacl local config
-    #
-    #     result is base64
-    #
-    #     its a combination of nacl symmetric encryption using secret and
-    #     asymetric encryption using the words
-    #
-    #     the result is a super strong encryption
-    #
-    #     to use
-    #
-    #     js_shell 'j.data.nacl.encrypt()'
-    #
-    #     """
-    #
-    #     message = message.strip()
-    #
-    #     if interactive:
-    #
-    #         secret, words = self._remember_get(secret, words)
-    #
-    #         if not secret:
-    #             secret = j.tools.console.askPassword("your secret")
-    #         if not message:
-    #             message = j.tools.console.askMultiline(
-    #                 "your message to encrypt")
-    #             message = message.strip()
-    #         if not words:
-    #             yn = j.tools.console.askYesNo(
-    #                 "do you wan to specify secret key as bip39 words?")
-    #             if yn:
-    #                 words = j.tools.console.askString("your bip39 words")
-    #             else:
-    #                 words = j.data.nacl.default.words
-    #
-    #         self._remember_set(secret, words)
-    #
-    #     else:
-    #         if not secret or not message:
-    #             raise RuntimeError("secret or message needs to be used")
-    #
-    #     if words == "":
-    #         words = j.data.nacl.default.words
-    #
-    #     # first encrypt symmetric
-    #     secret1 = j.data.hash.md5_string(secret)
-    #     secret1 = bytes(secret1, 'utf-8')
-    #     # print("secret1_jumpscale:%s"%secret1)
-    #
-    #     box = nacl.secret.SecretBox(secret1)
-    #     if j.data.types.str.check(message):
-    #         message = bytes(message, 'utf-8')
-    #     # print("msg_jumpscale:%s"%message)
-    #     res = box.encrypt(message)
-    #
-    #     # now encrypt asymetric using the words
-    #     privkeybytes = j.data.encryption.mnemonic.to_entropy(words)
-    #     # print("privkey_js:%s"%privkeybytes)
-    #
-    #     pk = PrivateKey(privkeybytes)
-    #
-    #     sb = SealedBox(pk.public_key)
-    #
-    #     res = sb.encrypt(res)
-    #
-    #     res = base64.encodestring(res)
-    #
-    #     print("encr_js:%s" % res)
-    #
-    #     # LETS VERIFY
-    #
-    #     msg = self.decrypt(
-    #         secret=secret,
-    #         message=res.decode('utf8'),
-    #         words=words,
-    #         interactive=interactive)
-    #
-    #     if j.data.types.bytes.check(message):
-    #         message = message.decode('utf8')
-    #
-    #     assert msg.strip() == message.strip()
-    #
-    #     if interactive:
-    #         print("encrypted text:\n*************\n")
-    #         print(res.decode('utf8'))
-    #
-    #     return res
-    #
-    # def decrypt(self, secret="", message="", words="", interactive=False):
-    #     """
-    #     use output from encrypt
-    #
-    #     js_shell 'j.data.nacl.decrypt()'
-    #
-    #     """
-    #
-    #     if interactive:
-    #
-    #         secret, words = self._remember_get(secret, words)
-    #
-    #         if not secret:
-    #             secret = j.tools.console.askPassword("your secret")
-    #         if not message:
-    #             message = j.tools.console.askMultiline(
-    #                 "your message to decrypt")
-    #             message = message.strip()
-    #         if not words:
-    #             yn = j.tools.console.askYesNo(
-    #                 "do you wan to specify secret key as bip39 words?")
-    #             if yn:
-    #                 words = j.tools.console.askString("your bip39 words")
-    #     else:
-    #         if not secret or not message:
-    #             raise RuntimeError("secret or message needs to be used")
-    #
-    #     secret = j.data.hash.md5_string(secret)
-    #     secret = bytes(secret, 'utf-8')
-    #
-    #     if not j.data.types.bytes.check(message):
-    #         message = bytes(message, 'utf8')
-    #
-    #     message = base64.decodestring(message)
-    #
-    #     if words == "":
-    #         words = j.data.nacl.default.words
-    #
-    #     privkeybytes = j.data.encryption.mnemonic.to_entropy(words)
-    #
-    #     pk = PrivateKey(privkeybytes)
-    #     sb = SealedBox(pk)
-    #
-    #     message = sb.decrypt(message)
-    #
-    #     # now decrypt symmetric
-    #     box = nacl.secret.SecretBox(secret)
-    #     message = box.decrypt(message)
-    #     message = message.decode(encoding='utf-8', errors='strict')
-    #
-    #     if interactive:
-    #         print("decrypted text:\n*************\n")
-    #         print(message.strip() + "\n")
-    #
-    #     return message
-
     def test(self):
         """
         js_shell 'j.data.nacl.test()'
         """
-
-        # res = self.encrypt("1111", "something", interactive=False)
-        # res2 = self.decrypt("1111", res, interactive=False)
-        # assert "something" == res2
-        #
-        # words = 'oxygen fun inner bachelor cherry pistol knife quarter ' \
-        #         'grass act ceiling wrap another input style profit middle ' \
-        #         'cake slight glance silk rookie caught parade'
-        # res3 = self.encrypt(
-        #     "1111",
-        #     "something",
-        #     words=words,
-        #     interactive=False)
-        # assert res != res3
-        #
-        # try:
-        #     res4 = self.decrypt("1111", res3, interactive=False)
-        # except Exception as e:
-        #     assert str(e).find("error occurred") != -1
-        #
-        # res4 = self.decrypt("1111", res3, words=words, interactive=False)
-        # assert "something" == res4
-
-        cl = self.default  # get's the default location & generate's keys
+        cl = self.get('test', secret='querty')  # get's the default location & generate's keys
 
         data = b"something"
         r = cl.sign(data)
@@ -286,21 +69,21 @@ class NACLFactory(j.application.JSBaseClass):
 
         assert b == b"something"
 
-        a = cl.encryptSymmetric("something", "qwerty")
-        b = cl.decryptSymmetric(a, b"qwerty")
+        a = cl.encryptSymmetric("something")
+        b = cl.decryptSymmetric(a)
         assert b == b"something"
 
-        a = cl.encryptSymmetric("something", "qwerty")
-        b = cl.decryptSymmetric(a, b"qwerty")
+        a = cl.encryptSymmetric("something")
+        b = cl.decryptSymmetric(a)
         assert b == b"something"
 
-        a = cl.encryptSymmetric(b"something", "qwerty")
-        b = cl.decryptSymmetric(a, b"qwerty")
+        a = cl.encryptSymmetric(b"something")
+        b = cl.decryptSymmetric(a)
         assert b == b"something"
 
         # now with hex
-        a = cl.encryptSymmetric(b"something", "qwerty", hex=True)
-        b = cl.decryptSymmetric(a, b"qwerty", hex=True)
+        a = cl.encryptSymmetric(b"something", hex=True)
+        b = cl.decryptSymmetric(a, hex=True)
         assert b == b"something"
 
         a = cl.encrypt(b"something")
@@ -323,7 +106,7 @@ class NACLFactory(j.application.JSBaseClass):
         js_shell 'j.data.nacl.test_perf()'
         """
 
-        cl = self.default  # get's the default location & generate's keys
+        cl = self.get('test', secret=b"qwerty")  # get's the default location & generate's keys
         data = b"something"
 
         nr = 10000
@@ -355,7 +138,7 @@ class NACLFactory(j.application.JSBaseClass):
         data2 = data * 20
         j.tools.timer.start("encryption/decryption symmetric")
         for i in range(nr):
-            a = cl.encryptSymmetric(data2, secret=secret)
-            b = cl.decryptSymmetric(a, secret=secret)
+            a = cl.encryptSymmetric(data2)
+            b = cl.decryptSymmetric(a)
             assert data2 == b
         j.tools.timer.stop(i)

--- a/Jumpscale/data/nacl/NACLFactory.py
+++ b/Jumpscale/data/nacl/NACLFactory.py
@@ -52,7 +52,7 @@ class NACLFactory(j.application.JSBaseClass):
         """
         js_shell 'j.data.nacl.test()'
         """
-        cl = self.get('test', secret='querty')  # get's the default location & generate's keys
+        cl = self.get('test', secret=b'qwerty')  # get's the default location & generate's keys
 
         data = b"something"
         r = cl.sign(data)


### PR DESCRIPTION
A temporary fix for #163 (dind't change the way things implemented in NACL).

## Description

* Allow passing NACL secret using an env variable (NACL_SECRET), for use cases like testing.
* Fix tests and some methods

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.