### PR TITLE
install: init env only when starting...

### DIFF
--- a/Jumpscale/__init__.py
+++ b/Jumpscale/__init__.py
@@ -188,7 +188,8 @@ rootdir = os.path.dirname(os.path.abspath(__file__))
 
 j.core.myenv = MyEnv
 
-j.core.myenv._init()
+j.core.myenv.init_config()
+j.core.myenv.init()
 
 
 

--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -1697,14 +1697,9 @@ class MyEnv():
 
         return config
 
-
     @staticmethod
-    def _init(force=False):
-        MyEnv.check_platform()
-
-        if MyEnv.__init:
-            return
-
+    def init_config():
+        """init config without creating any files or dirs anywhere"""
         if "DIR_CFG" in os.environ:
             DIR_CFG = os.environ["DIR_CFG"].strip()
         else:
@@ -1717,7 +1712,13 @@ class MyEnv():
             MyEnv.config_load()
         else:
             MyEnv.config = MyEnv.config_default_get()
-            MyEnv.config_save()
+
+    @staticmethod
+    def init(force=False):
+        if MyEnv.__init:
+            return
+
+        MyEnv.check_platform()
 
         if force or not MyEnv.state_exists("myenv_init"):
 
@@ -1749,11 +1750,8 @@ class MyEnv():
             Tools.execute(script,interactive=True)
 
 
-            MyEnv.config_load()
-
             if not "HOME" in MyEnv.config and "HOME" in os.environ:
                 MyEnv.config["DIR_HOME"] = copy.copy(os.environ["HOME"])
-                MyEnv.config_save()
 
             if not os.path.exists(MyEnv.config["DIR_BASE"]):
                 script = """
@@ -1789,8 +1787,6 @@ class MyEnv():
         installed = Tools.cmd_installed("git") and Tools.cmd_installed("ssh-agent")
         MyEnv.config["SSH_AGENT"]=installed
         MyEnv.config_save()
-
-
 
         MyEnv.__init = True
 
@@ -2091,9 +2087,7 @@ class JumpscaleInstaller():
         Tools.execute("cd /sandbox;source env.sh;js_init generate")
 
 
-
-MyEnv._init()
-
+MyEnv.init_config()
 
 
 try:

--- a/install/install.py
+++ b/install/install.py
@@ -68,8 +68,8 @@ def help():
     --portrange = 1 is the default means 8000-8099 on host gets mapped to 8000-8099 in docker
                   1 means 8100-8199 on host gets mapped to 8000-8099 in docker
                   2 means 8200-8299 on host gets mapped to 8000-8099 in docker
-                  
-    --image=/path/to/image.tar or name of image (use docker images) 
+
+    --image=/path/to/image.tar or name of image (use docker images)
                   ...
     --port = port of container SSH std is 9022 (normally not needed to use because is in portrange:22 e.g. 9122 if portrange 1)
 
@@ -302,6 +302,7 @@ elif "2" in args:
 
 
 if "1" in args or "2" in args:
+    IT.MyEnv.init()
     installer = IT.JumpscaleInstaller()
     installer.install()
 


### PR DESCRIPTION
Resolves: #160.

## Description

Init env (create related files/dirs) and check for the platform only when starting the installation process, not when just checking the system/host..etc, in case of e.g. docker, it would create unwanted files and dirs in the host itself.

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.