### PR TITLE
fixes #197 added Golang support for MacOS

### DIFF
--- a/Jumpscale/builder/runtimes/BuilderGolang.py
+++ b/Jumpscale/builder/runtimes/BuilderGolang.py
@@ -114,6 +114,8 @@ class BuilderGolang(j.builder.system._BaseClass):
         # only check for linux for now
         if j.core.platformtype.myplatform.isLinux:
             download_url = self.DOWNLOAD_URL.format(version='1.11.4', platform='linux', arch=self.current_arch)
+        elif j.core.platformtype.myplatform.isMac:
+            download_url = self.DOWNLOAD_URL.format(version='1.11.4', platform='darwin', arch=self.current_arch)
         else:
             raise j.exceptions.RuntimeError('platform not supported')
 

--- a/Jumpscale/builder/system/BuilderBaseClass.py
+++ b/Jumpscale/builder/system/BuilderBaseClass.py
@@ -113,9 +113,10 @@ class BuilderBaseClass(BaseClass):
             j.builder.tools.file_ensure(file_dest)
             j.builder.tools.file_write(file_dest, self.startup)
 
-        ld_dest = j.sal.fs.joinPaths(sandbox_dir, 'lib64/')
-        j.builder.tools.dir_ensure(ld_dest)
-        j.sal.fs.copyFile('/lib64/ld-linux-x86-64.so.2', ld_dest)
+        if j.core.platformtype.myplatform.isLinux:
+            ld_dest = j.sal.fs.joinPaths(sandbox_dir, 'lib64/')
+            j.builder.tools.dir_ensure(ld_dest)
+            j.sal.fs.copyFile('/lib64/ld-linux-x86-64.so.2', ld_dest)
 
         self._log_info('building flist')
         tarfile = '/tmp/{}.tar.gz'.format(self.NAME)


### PR DESCRIPTION
## Description

Adds an extra check for golang builder to install golang on macOSX.

Also fixes an error that occurs in the basebuilder class when it tries to copy a Linux so file which is not present on macOSX. This needs some reworking since this file is needed on zero-os.
