### PR TITLE
checks if j.core.db is there before trying to fetch secret, fixes #325

### DIFF
--- a/Jumpscale/data/nacl/NACL.py
+++ b/Jumpscale/data/nacl/NACL.py
@@ -196,10 +196,11 @@ class NACL(j.application.JSBaseClass):
             redis_key="secret_%s"%self.name
             key = j.sal.fs.readFile(self._path_encryptor_for_secret,binary=True)
             sb=nacl.secret.SecretBox(key)
-            r = j.core.db.get(redis_key)
-            if r is None:
-                self._error_raise("cannot find secret in memory, please use 'kosmos --init' to fix.")
-            secret = sb.decrypt(r)
+            if j.core.db:
+                r = j.core.db.get(redis_key)
+                if r is None:
+                    self._error_raise("cannot find secret in memory, please use 'kosmos --init' to fix.")
+                secret = sb.decrypt(r)
         else:
             #need to find an ssh agent now and only 1 key
             if j.clients.sshagent.available_1key_check():


### PR DESCRIPTION
Resolves: https://github.com/threefoldtech/jumpscaleX/issues/325

## Description

These changes check if there is a `j.core.db` and then try to get the `redis_key`.

Gives me following output when starting kosmos related to issue `325`

```
3BOTDEVEL:default:~: kosmos

sysctl: setting key "vm.overcommit_memory": Read-only file system
Wed 10 07:39:19 RedisFactory.py  - 297 - j.clients.redis:redisfactory       : mkdir -p /sandbox/var;redis-server --unixsocket /sandbox/var/redis.sock --port 6379 --maxmemory 100000000 --daemonize yes
76:C 10 Apr 07:39:19.536 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
76:C 10 Apr 07:39:19.536 # Redis version=4.0.9, bits=64, commit=00000000, modified=0, pid=76, just started
76:C 10 Apr 07:39:19.536 # Configuration loaded
Wed 10 07:39:19 BCDB.py          - 102 - bcdb:bcdb                          : BCDB INIT DONE:system
## There is an issue in the Jumpscale encryption layer. ##
cannot find secret in memory, please use 'kosmos --init' to fix.
```

After stopping and restarting my jsx docker, my kosmos secret is gone.

This fix gives me the following output gives me a good error what I need to do to regenerate a secret and that is: `kosmos --init`