### PR TITLE
raises a better error when secret in memory is lost

### DIFF
--- a/Jumpscale/data/nacl/NACL.py
+++ b/Jumpscale/data/nacl/NACL.py
@@ -196,7 +196,10 @@ class NACL(j.application.JSBaseClass):
             redis_key="secret_%s"%self.name
             key = j.sal.fs.readFile(self._path_encryptor_for_secret,binary=True)
             sb=nacl.secret.SecretBox(key)
-            r = j.core.db.get(redis_key)
+            try:
+                r = j.core.db.get(redis_key)
+            except AttributeError:
+                r = None
             if r is None:
                 self._error_raise("cannot find secret in memory, please use 'kosmos --init' to fix.")
             secret = sb.decrypt(r)


### PR DESCRIPTION
Refactors following error stack:

```
3BOTDEVEL:default:/: kosmos


EXCEPTION

        /sandbox/bin/kosmos                                          : 149 : if n.load(die=False) is False:
        /sandbox/lib/jumpscale/Jumpscale/data/nacl/NACL.py           : 199 : r = j.core.db.get(redis_key)

Tue 16 12:14:03 NACL.py          - 183 - load                               : EXCEPTION: 'NoneType' object has no attribute 'get'
CANNOT CONTINUE
```

And makes it like this:

```
3BOTDEVEL:default:/: kosmos
## There is an issue in the Jumpscale encryption layer. ##
cannot find secret in memory, please use 'kosmos --init' to fix.
```

Part of https://github.com/threefoldtech/jumpscaleX/issues/339