### PR TITLE
separate go lang tools to a helper class...

### DIFF
--- a/Jumpscale/builder/network/BuilderCoreDns.py
+++ b/Jumpscale/builder/network/BuilderCoreDns.py
@@ -1,4 +1,5 @@
 from Jumpscale import j
+from Jumpscale.builder.runtimes.BuilderGolang import BuilderGolangTools
 
 builder_method = j.builder.system.builder_method
 
@@ -14,14 +15,14 @@ CONFIGTEMPLATE="""
     }
     loadbalance
     reload 5s
-}        
+}
 """
 
-class BuilderCoreDns(j.builder.system._BaseClass):
+class BuilderCoreDns(BuilderGolangTools, j.builder.system._BaseClass):
     NAME = "coredns"
 
-    def _init(self):
-        self.package_path = j.builder.runtimes.golang.package_path_get('coredns', 'github.com/coredns')
+    def profile_builder_set(self):
+        self.profile.env_set('GO111MODULE', 'on')
 
     @builder_method()
     def build(self):
@@ -34,16 +35,16 @@ class BuilderCoreDns(j.builder.system._BaseClass):
         # install golang
         j.builder.runtimes.golang.install()
         j.builder.db.etcd.install()
-        j.builder.runtimes.golang.get('github.com/coredns/coredns', install=False, update=True)
-        
+
+        # https://github.com/coredns/coredns#compilation-from-source
+
         # go to package path and build (for coredns)
         C = """
-        cd {}
-        git remote add threefoldtech_coredns https://github.com/threefoldtech/coredns
-        git fetch threefoldtech_coredns
-        git checkout threefoldtech_coredns/master
+        cd {DIR_BUILD}
+        git clone https://github.com/threefoldtech/coredns
+        cd coredns
         make
-        """.format(self.package_path)
+        """
         self._execute(C)
 
     @builder_method()
@@ -53,15 +54,13 @@ class BuilderCoreDns(j.builder.system._BaseClass):
 
         installs and runs coredns server with redis plugin
         """
-        src = '{}/coredns'.format(self.package_path)
-        dest = self._replace('{DIR_BIN}/coredns')
-        self._copy(src=src, dst=dest)
+        self._copy('{DIR_BUILD}/coredns', '{DIR_BIN}/coredns')
         j.sal.fs.writeFile(filename='/sandbox/cfg/coredns.conf', contents=CONFIGTEMPLATE)
 
     def clean(self):
-        self._remove(self.package_path)
+        self._remove(self.DIR_BUILD)
         self._remove(self.DIR_SANDBOX)
-    
+
     @property
     def startup_cmds(self):
         cmd = "/sandbox/bin/coredns -conf /sandbox/cfg/coredns.conf"

--- a/Jumpscale/builder/runtimes/BuilderGolang.py
+++ b/Jumpscale/builder/runtimes/BuilderGolang.py
@@ -19,7 +19,7 @@ class BuilderGolangTools(j.builder.system._BaseClass):
         if not profile:
             profile = self.bash.profile
 
-        # profile.env_set('GOROOT', self.DIR_GO_ROOT)
+        profile.env_set('GOROOT', self.DIR_GO_ROOT)
         profile.env_set('GOPATH', self.DIR_GO_PATH)
 
         # remove old parts of profile
@@ -93,7 +93,7 @@ class BuilderGolangTools(j.builder.system._BaseClass):
             flags += ' -u'
         if verbose:
             flags += ' -v'
-        self._execute('go get %s %s' % (flags, url), die=die)
+        self._execute('go get %s %s' % (flags, url), timeout=10000, die=die)
 
     def package_path_get(self, name, host='github.com', go_path=None):
         """A helper method to get a package path installed by `get`
@@ -134,7 +134,7 @@ class BuilderGolangTools(j.builder.system._BaseClass):
         self._execute('cd %s && godep restore' % dest)
 
 
-class BuilderGolang(BuilderGolangTools, j.builder.system._BaseClass):
+class BuilderGolang(BuilderGolangTools):
 
     NAME = 'go'
     STABLE_VERSION = '1.12.1'
@@ -185,20 +185,6 @@ class BuilderGolang(BuilderGolangTools, j.builder.system._BaseClass):
         if j.core.platformtype.myplatform.is32bit:
             return '386'
         return 'amd64'
-
-    def update_profile_paths(self, profile=None):
-        if not profile:
-            profile = self.bash.profile
-
-        profile.env_set('GOROOT', self.DIR_GO_ROOT)
-        profile.env_set('GOPATH', self.DIR_GO_PATH)
-
-        # remove old parts of profile
-        # and add them to PATH (without existence check)
-        profile.path_delete("/go/")
-        profile.path_delete("/go_proj")
-        profile.path_add(self.DIR_GO_PATH_BIN, check_exists=False)
-        profile.path_add(self.DIR_GO_ROOT_BIN, check_exists=False)
 
     @builder_method()
     def install(self):

--- a/Jumpscale/builder/runtimes/BuilderGolang.py
+++ b/Jumpscale/builder/runtimes/BuilderGolang.py
@@ -3,14 +3,145 @@ from Jumpscale import j
 builder_method = j.builder.system.builder_method
 
 
-class BuilderGolang(j.builder.system._BaseClass):
+class BuilderGolangTools(j.builder.system._BaseClass):
+    NAME = 'golangtools'
+
+    def _init(self):
+        self.base_dir = self._replace('{DIR_BASE}')
+
+        self.env = self.bash.profile
+        self.DIR_GO_ROOT = self.tools.joinpaths(self.base_dir, 'go')
+        self.DIR_GO_PATH = self.tools.joinpaths(self.base_dir, 'go_proj')
+        self.DIR_GO_ROOT_BIN = self.tools.joinpaths(self.DIR_GO_ROOT, 'bin')
+        self.DIR_GO_PATH_BIN = self.tools.joinpaths(self.DIR_GO_PATH, 'bin')
+
+    def update_profile_paths(self, profile=None):
+        if not profile:
+            profile = self.bash.profile
+
+        # profile.env_set('GOROOT', self.DIR_GO_ROOT)
+        profile.env_set('GOPATH', self.DIR_GO_PATH)
+
+        # remove old parts of profile
+        # and add them to PATH (without existence check)
+        profile.path_delete("/go/")
+        profile.path_delete("/go_proj")
+        profile.path_add(self.DIR_GO_PATH_BIN, check_exists=False)
+        profile.path_add(self.DIR_GO_ROOT_BIN, check_exists=False)
+
+    @builder_method()
+    def goraml(self):
+        """install (using go get) goraml.
+
+        :param reset: reset installation, defaults to False
+        :type reset: bool, optional
+        """
+        self.bindata()
+
+        C = '''
+        go get -u github.com/tools/godep
+        go get -u github.com/jteeuwen/go-bindata/...
+        go get -u github.com/Jumpscale/go-raml
+        set -ex
+        cd {DIR_GO_PATH}/src/github.com/Jumpscale/go-raml
+        sh build.sh
+        '''
+        self._execute(C)
+        self._done_set('goraml')
+
+    @builder_method()
+    def bindata(self):
+        """install (using go get) go-bindata.
+
+        :param reset: reset installation, defaults to False
+        :type reset: bool, optional
+        """
+
+        C = '''
+        set -ex
+        go get -u github.com/jteeuwen/go-bindata/...
+        cd {DIR_GO_PATH}/src/github.com/jteeuwen/go-bindata/go-bindata
+        go build
+        go install
+        '''
+        self._execute(C)
+
+    @builder_method()
+    def glide(self):
+        """install glide"""
+        self.tools.file_download(
+            'https://glide.sh/get', '{DIR_TEMP}/installglide.sh', minsizekb=4)
+        self._execute('. {DIR_TEMP}/installglide.sh')
+        self._done_set('glide')
+
+    def get(self, url, install=True, update=False, die=True, verbose=False):
+        """go get a package
+
+        :param url: pacakge url e.g. github.com/tools/godep
+        :type url:  str
+        :param install: build and install the repo if false will only get the repo, defaults to True
+        :type install: bool, optional
+        :param update: will update requirements if they exist, defaults to True
+        :type update: bool, optional
+        :param die: raise a RuntimeError if failed, defaults to True
+        :type die: bool, optional
+        """
+        flags = ''
+        if not install:
+            flags = ' -d'
+        if update:
+            flags += ' -u'
+        if verbose:
+            flags += ' -v'
+        self._execute('go get %s %s' % (flags, url), die=die)
+
+    def package_path_get(self, name, host='github.com', go_path=None):
+        """A helper method to get a package path installed by `get`
+        Will use this builder's default go path if go_path is not provided
+
+        :param name: pacakge name e.g. containous/go-bindata
+        :type name: str
+        :param host: host, defaults to github.com
+        :type host: str
+        :param go_path: GOPATH, defaults to None
+        :type go_path: str
+
+        :return: go package path
+        :rtype: str
+        """
+        if not go_path:
+            go_path = self.DIR_GO_PATH
+        return self.tools.joinpaths(go_path, 'src', host, name)
+
+    def godep(self, url, branch=None, depth=1):
+        """install a package using godep
+
+        :param url: package url e.g. github.com/tools/godep
+        :type url: str
+        :param branch: a specific branch, defaults to None
+        :type branch: str, optional
+        :param depth: depth to pull with, defaults to 1
+        :type depth: int, optional
+        """
+        pullurl = "git@%s.git" % url.replace('/', ':', 1)
+
+        dest = j.clients.git.pullGitRepo(
+            pullurl,
+            branch=branch,
+            depth=depth,
+            dest='%s/src/%s' % (self.DIR_GO_PATH, url),
+            ssh=False)
+        self._execute('cd %s && godep restore' % dest)
+
+
+class BuilderGolang(BuilderGolangTools, j.builder.system._BaseClass):
 
     NAME = 'go'
-    STABLE_VERSION = '1.12'
+    STABLE_VERSION = '1.12.1'
     DOWNLOAD_URL = 'https://dl.google.com/go/go{version}.{platform}-{arch}.tar.gz'
 
     def _init(self):
-        self.base_dir = j.core.tools.text_replace('{DIR_BASE}')
+        self.base_dir = self._replace('{DIR_BASE}')
 
         self.env = self.bash.profile
         self.DIR_GO_ROOT = self.tools.joinpaths(self.base_dir, 'go')
@@ -99,115 +230,6 @@ class BuilderGolang(j.builder.system._BaseClass):
 
         self.get("github.com/tools/godep")
         self._done_set("install")
-
-    @builder_method()
-    def goraml(self):
-        """install (using go get) goraml.
-
-        :param reset: reset installation, defaults to False
-        :type reset: bool, optional
-        """
-
-        self.install()
-        self.bindata()
-
-        C = '''
-        go get -u github.com/tools/godep
-        go get -u github.com/jteeuwen/go-bindata/...
-        go get -u github.com/Jumpscale/go-raml
-        set -ex
-        cd {DIR_GO_PATH}/src/github.com/Jumpscale/go-raml
-        sh build.sh
-        '''
-        self._execute(C)
-        self._done_set('goraml')
-
-    @builder_method()
-    def bindata(self):
-        """install (using go get) go-bindata.
-
-        :param reset: reset installation, defaults to False
-        :type reset: bool, optional
-        """
-
-        C = '''
-        set -ex
-        go get -u github.com/jteeuwen/go-bindata/...
-        cd {DIR_GO_PATH}/src/github.com/jteeuwen/go-bindata/go-bindata
-        go build
-        go install
-        '''
-        self._execute(C)
-        self._done_set('bindata')
-
-    def glide(self):
-        """install glide"""
-        if self._done_get('glide'):
-            return
-        self.tools.file_download(
-            'https://glide.sh/get', '{DIR_TEMP}/installglide.sh', minsizekb=4)
-        self._execute('. {DIR_TEMP}/installglide.sh')
-        self._done_set('glide')
-
-    def get(self, url, install=True, update=True, die=True):
-        """go get a package
-
-        :param url: pacakge url e.g. github.com/tools/godep
-        :type url:  str
-        :param install: build and install the repo if false will only get the repo, defaults to True
-        :type install: bool, optional
-        :param update: will update requirements if they exist, defaults to True
-        :type update: bool, optional
-        :param die: raise a RuntimeError if failed, defaults to True
-        :type die: bool, optional
-        """
-        download_flag = ''
-        update_flag = ''
-        if not install:
-            download_flag = '-d'
-        if update:
-            update_flag = '-u'
-        self._execute('go get %s -v %s %s' % (download_flag, update_flag, url), die=die)
-
-    def package_path_get(self, name, host='github.com', go_path=None):
-        """A helper method to get a package path installed by `get`
-        Will use this builder's default go path if go_path is not provided
-
-        :param name: pacakge name e.g. containous/go-bindata
-        :type name: str
-        :param host: host, defaults to github.com
-        :type host: str
-        :param go_path: GOPATH, defaults to None
-        :type go_path: str
-
-        :return: go package path
-        :rtype: str
-        """
-        if not go_path:
-            go_path = self.DIR_GO_PATH
-        return self.tools.joinpaths(go_path, 'src', host, name)
-
-    def godep(self, url, branch=None, depth=1):
-        """install a package using godep
-
-        :param url: package url e.g. github.com/tools/godep
-        :type url: str
-        :param branch: a specific branch, defaults to None
-        :type branch: str, optional
-        :param depth: depth to pull with, defaults to 1
-        :type depth: int, optional
-        """
-
-        self.clean_src_path()
-        pullurl = "git@%s.git" % url.replace('/', ':', 1)
-
-        dest = j.clients.git.pullGitRepo(
-            pullurl,
-            branch=branch,
-            depth=depth,
-            dest='%s/src/%s' % (self.DIR_GO_PATH, url),
-            ssh=False)
-        self._execute('cd %s && godep restore' % dest)
 
     def test(self):
         """test go installation

--- a/Jumpscale/builder/storage/BuilderMinio.py
+++ b/Jumpscale/builder/storage/BuilderMinio.py
@@ -1,15 +1,21 @@
 from Jumpscale import j
+from Jumpscale.builder.runtimes.BuilderGolang import BuilderGolangTools
+
 import os
 import textwrap
 builder_method = j.builder.system.builder_method
 
 
 
-class BuilderMinio(j.builder.system._BaseClass):
+class BuilderMinio(BuilderGolangTools):
     NAME = "minio"
 
     def _init(self):
+        super()._init()
         self.datadir = ''
+
+    def profile_builder_set(self):
+        self.profile.env_set('GO111MODULE', 'on')
 
     @builder_method()
     def build(self):
@@ -17,18 +23,14 @@ class BuilderMinio(j.builder.system._BaseClass):
         Builds minio
         """
         j.builder.runtimes.golang.install()
-        self.profile.env_set('GO111MODULE', 'on')
-        cmd = """
-        go get github.com/minio/minio
-        """
-        self._execute(cmd, timeout=10000)
+        self.get('github.com/minio/minio')
 
     @builder_method()
     def install(self):
         """
         Installs minio
         """
-        self._copy('{}/bin/minio'.format(j.builder.runtimes.golang.DIR_GO_PATH), '{DIR_BIN}')
+        self._copy('{}/bin/minio'.format(self.DIR_GO_PATH), '{DIR_BIN}')
 
     @property
     def startup_cmds(self):
@@ -49,7 +51,7 @@ class BuilderMinio(j.builder.system._BaseClass):
     def clean(self):
         self._remove(self.DIR_SANDBOX)
         self._remove('{}/bin/minio'.format(j.builder.runtimes.golang.DIR_GO_PATH))
-    
+
     @builder_method()
     def sandbox(self):
         bin_dest = j.sal.fs.joinPaths(self.DIR_SANDBOX, "sandbox")

--- a/Jumpscale/builder/web/BuilderCaddy.py
+++ b/Jumpscale/builder/web/BuilderCaddy.py
@@ -70,7 +70,7 @@ func main() {
 }"""
 
 
-class BuilderCaddy(BuilderGolangTools, j.builder.system._BaseClass):
+class BuilderCaddy(BuilderGolangTools):
     NAME = "caddy"
     PLUGINS = ['iyo', 'filemanager']  # PLEASE ADD MORE PLUGINS #TODO:*1
     VERSION = 'master' # make sure the way to build with plugin is ok

--- a/Jumpscale/builder/web/BuilderCaddy.py
+++ b/Jumpscale/builder/web/BuilderCaddy.py
@@ -1,4 +1,5 @@
 from Jumpscale import j
+from Jumpscale.builder.runtimes.BuilderGolang import BuilderGolangTools
 
 builder_method = j.builder.system.builder_method
 
@@ -51,54 +52,37 @@ PLUGIN_DIRECTIVES = {
 }
 
 
-class BuilderCaddy(j.builder.system._BaseClass):
+# see https://github.com/mholt/caddy#build
+CADDY_RUNNER = """
+package main
+
+import (
+	"github.com/mholt/caddy/caddy/caddymain"
+
+	// plug in plugins here, for example:
+%s
+)
+
+func main() {
+	// optional: disable telemetry
+	// caddymain.EnableTelemetry = false
+	caddymain.Run()
+}"""
+
+
+class BuilderCaddy(BuilderGolangTools, j.builder.system._BaseClass):
     NAME = "caddy"
     PLUGINS = ['iyo', 'filemanager']  # PLEASE ADD MORE PLUGINS #TODO:*1
+    VERSION = 'master' # make sure the way to build with plugin is ok
 
     def _init(self):
-        self.go_runtime = j.builder.runtimes.golang
-        self.package_path = self.go_runtime.package_path_get('mholt/caddy')
-        self.plugins_file = self.tools.joinpaths(self.package_path, 'caddyhttp/httpserver/plugin.go')
-        self.main_file = self.tools.joinpaths(self.package_path, 'caddy/caddymain/run.go')
+        super()._init()
+        self.package_path = self.package_path_get('mholt/caddy')
 
     def clean(self):
         self.stop()
         self._init()
         j.builder.tools.dir_remove("{DIR_BIN}/caddy")
-
-    def _append_after(self, file_path, match, new_line):
-        content = self.tools.file_read(file_path)
-
-        lines = content.split('\n')
-
-        line_no = None
-        match = match.lower()
-        for i, line in enumerate(lines):
-            if match in line.lower():
-                line_no = i
-                break
-
-        if line_no is None:
-            raise ValueError('cannot find "%s" in content' % match)
-
-        lines.insert(line_no + 1, new_line)
-        self.tools.file_write(file_path, '\n'.join(lines))
-
-    def update_imports_and_directves(self, url, directive=None):
-        self._append_after(
-            self.main_file, 'This is where other plugins get plugged in (imported)',
-            '_ "%s"' % url
-        )
-        self._execute('gofmt -w %s' % self.main_file)
-
-        if not directive:
-            return
-
-        self._append_after(
-            self.plugins_file, '"prometheus",', '"%s",' % directive
-        )
-
-        self._execute('gofmt -w %s' % self.main_file)
 
     def get_plugin(self, name):
         """get a supported plugin
@@ -112,12 +96,12 @@ class BuilderCaddy(j.builder.system._BaseClass):
             raise j.exceptions.RuntimeError('plugin not supported')
 
         url = ALL_PLUGINS[name]
-        self.go_runtime.get(url, install=False)
-        self.update_imports_and_directves(url, PLUGIN_DIRECTIVES.get(name))
+        self.get(url, install=False)
 
     def profile_builder_set(self):
         # make sure go binaries are in path while building
-        self.go_runtime.update_profile_paths(self.bash.profile)
+        self.profile.env_set('GO111MODULE', 'on')
+        self.update_profile_paths(self.bash.profile)
 
     @builder_method()
     def build(self, plugins=None):
@@ -132,19 +116,24 @@ class BuilderCaddy(j.builder.system._BaseClass):
             raise j.exceptions.RuntimeError("only ubuntu supported")
 
         # install go runtime
-        self.go_runtime.install()
+        j.builder.runtimes.golang.install()
 
-        # get caddy and plugins source
-        self.go_runtime.get("github.com/mholt/caddy/caddy")
+        # get caddy and plugins
         if not plugins:
             plugins = self.PLUGINS
 
         for plugin in plugins:
             self.get_plugin(plugin)
 
-        # build caddy
-        self.go_runtime.get("github.com/caddyserver/builds")
-        self._execute("cd $GOPATH/src/github.com/mholt/caddy/caddy;go run build.go && cp caddy $GOPATH/bin")
+        # build caddy with a plugins
+        plugin_imports = '\n'.join([
+            '\t_ "%s"' % ALL_PLUGINS[name] for name in plugins
+        ])
+
+        self.get('github.com/mholt/caddy/caddy@%s' % self.VERSION)
+        runner_file = self._replace('{DIR_BUILD}/caddy.go')
+        self.tools.file_write(runner_file, CADDY_RUNNER % plugin_imports)
+        self._execute('cd {DIR_BUILD} && gofmt caddy.go && go mod init caddy && go install')
 
     @builder_method()
     def install(self, plugins=None):
@@ -158,7 +147,7 @@ class BuilderCaddy(j.builder.system._BaseClass):
         """
 
         caddy_bin_path = self.tools.joinpaths(
-            self.go_runtime.DIR_GO_PATH_BIN, self.NAME
+            self.DIR_GO_PATH_BIN, self.NAME
         )
         j.builder.tools.file_copy(caddy_bin_path, "{DIR_BIN}/caddy")
 
@@ -171,8 +160,7 @@ class BuilderCaddy(j.builder.system._BaseClass):
     def sandbox(self, reset=False, zhub_client=None, flist_create=False):
         bin_dest = j.sal.fs.joinPaths("/sandbox/var/build", "{}/sandbox".format(self.DIR_SANDBOX))
         self.tools.dir_ensure(bin_dest)
-        caddy_bin_path = self.tools.joinpaths(
-            "{go_path}/src/github.com/mholt/caddy/caddy".format(go_path=self.go_runtime.DIR_GO_PATH), self.NAME)
+        caddy_bin_path = self.tools.joinpaths(self.package_path, '/caddy', self.NAME)
         self.tools.file_copy(caddy_bin_path, bin_dest)
 
     def _test(self, name=""):


### PR DESCRIPTION
Resolves: #123, #288 and #287.

## Description

Some builders need separate directories or custom flags, this will enable tools like `go get` to run in the context (also profile) of any builder instead of `BuilderGolang` itself.

Updated all the builders the depends on these tools.

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.