### PR TITLE
builders: fix builder_method decorator #354...

### DIFF
--- a/Jumpscale/builder/system/BuilderBaseClass.py
+++ b/Jumpscale/builder/system/BuilderBaseClass.py
@@ -49,6 +49,13 @@ class builder_method(object):
 
         arg_names = arg_names[:len(args)]
         kwargs.update(dict(zip(arg_names, args)))
+
+        signature = inspect.signature(func)
+        for _, param in signature.parameters.items():
+            if param.name not in kwargs:
+                if not isinstance(param.default, inspect._empty):
+                    kwargs[param.name] = param.default
+
         return kwargs
 
     def apply_method(self, func, kwargs):

--- a/Jumpscale/builder/system/BuilderDummy.py
+++ b/Jumpscale/builder/system/BuilderDummy.py
@@ -11,7 +11,7 @@ class BuilderDummy(j.builder.system._BaseClass):
         self._log_debug('build called reset=%s' % reset)
 
     @builder_method()
-    def install(self):
+    def install(self, reset=True):
         self._log_debug('install called')
 
     @builder_method()

--- a/Jumpscale/builder/system/BuilderDummy.py
+++ b/Jumpscale/builder/system/BuilderDummy.py
@@ -1,0 +1,19 @@
+from Jumpscale import j
+
+builder_method = j.builder.system.builder_method
+
+
+class BuilderDummy(j.builder.system._BaseClass):
+    NAME = 'dummy'
+
+    @builder_method()
+    def build(self, reset=False):
+        self._log_debug('build called reset=%s' % reset)
+
+    @builder_method()
+    def install(self):
+        self._log_debug('install called')
+
+    @builder_method()
+    def sandbox(self, zhub_client=None):
+        self._log_debug('sandbox called with zhubclient=%s' % zhub_client)

--- a/Jumpscale/builder/system/BuilderSystemFactory.py
+++ b/Jumpscale/builder/system/BuilderSystemFactory.py
@@ -2,9 +2,8 @@
 
 from Jumpscale import j
 
-from .BuilderBaseClass import *
+from .BuilderBaseClass import BuilderBaseClass, builder_method
 from .BuilderBaseFactoryClass import BuilderBaseFactoryClass
-
 
 
 class BuilderSystemPackage(j.application.JSBaseClass):
@@ -25,6 +24,7 @@ class BuilderSystemPackage(j.application.JSBaseClass):
         self._ssh = None
         self._user = None
         self._bash = None
+        self._dummy = None
 
         j.clients.redis.core_get()
 
@@ -44,7 +44,6 @@ class BuilderSystemPackage(j.application.JSBaseClass):
             from .BuilderSystemPackage import BuilderSystemPackage
             self._package = BuilderSystemPackage()
         return self._package
-
 
     @property
     def python_pip(self):
@@ -67,7 +66,6 @@ class BuilderSystemPackage(j.application.JSBaseClass):
             self._net = BuilderNet()
         return self._net
 
-
     @property
     def ssh(self):
         if self._ssh is None:
@@ -81,3 +79,10 @@ class BuilderSystemPackage(j.application.JSBaseClass):
             from .BuilderUser import BuilderUser
             self._user = BuilderUser()
         return self._user
+
+    @property
+    def dummy(self):
+        if self._dummy is None:
+            from .BuilderDummy import BuilderDummy
+            self._dummy = BuilderDummy()
+        return self._dummy


### PR DESCRIPTION
Resolves: #354.

## Description

This solution is not the best, and i think we can have a simpler one.

Inspecting decorated function arguments, which allow passing reset and other arguments to decorated method, also, make sure positional arguments are respected (not ignored).

This will ensure the decorated function gets called with all arguments defined in its signature (whether they are positional or keyworded).

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.