### PR TITLE
Prompt user to enter secret when not found in loading secret in NACL

### DIFF
--- a/Jumpscale/__init__.py
+++ b/Jumpscale/__init__.py
@@ -85,6 +85,7 @@ class Core:
 
         self._db = fakeredis.FakeStrictRedis()
         self._db_fakeredis = True
+        return self._db
 
     @property
     def db(self):

--- a/Jumpscale/data/nacl/NACL.py
+++ b/Jumpscale/data/nacl/NACL.py
@@ -197,8 +197,16 @@ class NACL(j.application.JSBaseClass):
             except AttributeError:
                 r = None
             if r is None:
-                self._error_raise("cannot find secret in memory, please use 'kosmos --init' to fix.")
-            secret = sb.decrypt(r)
+                secret = j.tools.console.askPassword(
+                    "Provide the secret used to encrypt/decrypt your private key. If not available, please use kosmos --init"
+                )
+                if secret.strip() in [""]:
+                    self._error_raise("Secret cannot be empty")
+                secret = self._hash(secret)
+                if isinstance(secret, str):
+                    secret = secret.encode()
+                r = sb.encrypt(secret)
+                j.core.db.set(redis_key, r)
         else:
             # need to find an ssh agent now and only 1 key
             if j.clients.sshagent.available_1key_check():


### PR DESCRIPTION
Resolves: https://github.com/threefoldtech/jumpscaleX/issues/346

## Description

Add the option of prompting the user to enter the secret when it's not found during loading. This secret should match the old secret to be able to decrypt any old data. Otherwise this data can't be decrypted again.
