### PR TITLE
gdrive client: fix the schema url not to conflict with sonic client

### DIFF
--- a/Jumpscale/clients/gdrive/GDriveClient.py
+++ b/Jumpscale/clients/gdrive/GDriveClient.py
@@ -28,7 +28,7 @@ JSConfigClient = j.application.JSBaseConfigClass
 
 class GDriveClient(JSConfigClient):
     _SCHEMATEXT = """
-    @url =  jumpscale.sonic.client
+    @url =  jumpscale.gdrive.client
     name* = "" (S)
     credfile = "" (S)
     """


### PR DESCRIPTION
Resolves: https://github.com/threefoldtech/jumpscaleX/issues/552