### PR TITLE
markdowndocs: fix team macro avatar paths

### DIFF
--- a/Jumpscale/tools/markdowndocs/macros/team.py
+++ b/Jumpscale/tools/markdowndocs/macros/team.py
@@ -69,7 +69,7 @@ def team(doc, link, order="random", projects=None, contribution_types=None, **kw
             if basename.startswith("publicinfo") and extname == "toml":
                 person_data.update(j.data.serializers.toml.load(filepath))
             elif extname in ("png", "jpg", "jpeg"):
-                person_data["avatar"] = "%s/%s" % (doc.path_dir_rel, basename)
+                person_data["avatar"] = j.sal.fs.joinPaths(doc.path_dir_rel, basename)
                 dest = j.sal.fs.joinPaths(doc.docsite.outpath, doc.path_dir_rel, basename)
                 j.sal.fs.copyFile(filepath, dest, createDirIfNeeded=True)
 


### PR DESCRIPTION
## Description

A small fix for avatar paths when collecting team data.

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.