### PR TITLE
Fix github repo link in openpublish

### DIFF
--- a/Jumpscale/tools/markdowndocs/DocSite.py
+++ b/Jumpscale/tools/markdowndocs/DocSite.py
@@ -610,6 +610,11 @@ class DocSite(j.application.JSBaseClass):
         # j.sal.fs.copyDirTree(self.path, self.outpath, overwriteFiles=True, ignoredir=['.*'], ignorefiles=[
         #               "*.md", "*.toml", "_*", "*.yaml", ".*"], rsync=True, recursive=True, rsyncdelete=True)
 
+        # Create file with extra content to be loaded in docsites
+        if self.account and self.repo:
+            repo_info = "https://github.com/%s/%s" % (self.account, self.repo)
+            j.sal.fs.writeFile(filename=dest + "/.data", contents=repo_info, append=False)
+
         keys = [item for item in self.docs.keys()]
         keys.sort()
         for key in keys:


### PR DESCRIPTION
Resolves: https://github.com/threefoldtech/OpenPublish/issues/9

+in OpenPublish the following changes are done as well on [development_repo_data] branch:
https://github.com/threefoldtech/OpenPublish/pull/25

## Description

The repository url is saved to a file when creating the docsite, then read when loading and so used directly instead of hard coding the link concatenated with the name of the docsite


