### PR TITLE
zos client: rename node.name to node.node_id to prevent conflict with config manager

### DIFF
--- a/Jumpscale/clients/zero_os/ZeroOSClient.py
+++ b/Jumpscale/clients/zero_os/ZeroOSClient.py
@@ -36,3 +36,8 @@ class ZeroOSClient(j.application.JSBaseConfigClass, Node):
         except AttributeError:
             # not a client attribute
             pass
+
+        # force re-creation of the redis client
+        # when the config is changed
+        if key in ['host','port','password','unixsocket']:
+            self.client._redis = None

--- a/Jumpscale/clients/zero_os/ZeroOSClient.py
+++ b/Jumpscale/clients/zero_os/ZeroOSClient.py
@@ -39,5 +39,5 @@ class ZeroOSClient(j.application.JSBaseConfigClass, Node):
 
         # force re-creation of the redis client
         # when the config is changed
-        if key in ['host','port','password','unixsocket']:
+        if key in ["host", "port", "password", "unixsocket"]:
             self.client._redis = None

--- a/Jumpscale/clients/zero_os/protocol/Response.py
+++ b/Jumpscale/clients/zero_os/protocol/Response.py
@@ -161,7 +161,7 @@ class Response:
         after the 5 min is gone, the job result is no more fetchable
         :return: bool
         """
-        r = self._client._redis
+        r = self._client.redis
         flag = "{}:flag".format(self._queue)
         return bool(r.exists(flag))
 
@@ -171,7 +171,7 @@ class Response:
         Returns true if job still in running state
         :return:
         """
-        r = self._client._redis
+        r = self._client.redis
         flag = "{}:flag".format(self._queue)
         if bool(r.exists(flag)):
             ttl = r.ttl(flag)
@@ -209,7 +209,7 @@ class Response:
             raise Exception("callback must be callable")
 
         queue = "stream:%s" % self.id
-        r = self._client._redis
+        r = self._client.redis
 
         count = 0
         while True:
@@ -249,7 +249,7 @@ class Response:
         """
         if timeout is None:
             timeout = self._client.timeout
-        r = self._client._redis
+        r = self._client.redis
         start = time.time()
         maxwait = timeout
         while maxwait > 0:

--- a/Jumpscale/sal_zos/capacity/Capacity.py
+++ b/Jumpscale/sal_zos/capacity/Capacity.py
@@ -69,7 +69,7 @@ class Capacity:
 
         report = self.total_report()
         data = dict(
-            node_id=self._node.name,
+            node_id=self._node.node_id,
             location=report.location,
             total_resources=report.total(),
             robot_address=robot_address,
@@ -98,12 +98,12 @@ class Capacity:
 
         report = self.reality_report()
         data = dict(
-            node_id=self._node.name, farmer_id=farmer_id, cru=report.CRU, mru=report.MRU, hru=report.HRU, sru=report.SRU
+            node_id=self._node.node_id, farmer_id=farmer_id, cru=report.CRU, mru=report.MRU, hru=report.HRU, sru=report.SRU
         )
 
         client = self.directory()
 
-        resp = client.api.UpdateActualUsedCapacity(data=data, node_id=self._node.name)
+        resp = client.api.UpdateActualUsedCapacity(data=data, node_id=self._node.node_id)
         resp.raise_for_status()
 
     def update_reserved(self, vms, vdisks, gateways):
@@ -113,10 +113,10 @@ class Capacity:
 
         report = j.tools.capacity.reservation_parser.get_report(vms, vdisks, gateways)
         data = dict(
-            node_id=self._node.name, farmer_id=farmer_id, cru=report.CRU, mru=report.MRU, hru=report.HRU, sru=report.SRU
+            node_id=self._node.node_id, farmer_id=farmer_id, cru=report.CRU, mru=report.MRU, hru=report.HRU, sru=report.SRU
         )
 
         client = self.directory()
 
-        resp = client.api.UpdateReservedCapacity(data=data, node_id=self._node.name)
+        resp = client.api.UpdateReservedCapacity(data=data, node_id=self._node.node_id)
         resp.raise_for_status()

--- a/Jumpscale/sal_zos/capacity/Capacity.py
+++ b/Jumpscale/sal_zos/capacity/Capacity.py
@@ -98,7 +98,12 @@ class Capacity:
 
         report = self.reality_report()
         data = dict(
-            node_id=self._node.node_id, farmer_id=farmer_id, cru=report.CRU, mru=report.MRU, hru=report.HRU, sru=report.SRU
+            node_id=self._node.node_id,
+            farmer_id=farmer_id,
+            cru=report.CRU,
+            mru=report.MRU,
+            hru=report.HRU,
+            sru=report.SRU,
         )
 
         client = self.directory()
@@ -113,7 +118,12 @@ class Capacity:
 
         report = j.tools.capacity.reservation_parser.get_report(vms, vdisks, gateways)
         data = dict(
-            node_id=self._node.node_id, farmer_id=farmer_id, cru=report.CRU, mru=report.MRU, hru=report.HRU, sru=report.SRU
+            node_id=self._node.node_id,
+            farmer_id=farmer_id,
+            cru=report.CRU,
+            mru=report.MRU,
+            hru=report.HRU,
+            sru=report.SRU,
         )
 
         client = self.directory()

--- a/Jumpscale/sal_zos/healthchecks/context_switch.py
+++ b/Jumpscale/sal_zos/healthchecks/context_switch.py
@@ -10,7 +10,7 @@ Monitors CPU context switching
 
 class ContextSwitch(HealthCheckRun):
     def __init__(self, node, warn=600000, error=1000000):
-        super().__init__("context-switch", "Context Switch", "Hardware", "/nodes/{}".format(node.name))
+        super().__init__("context-switch", "Context Switch", "Hardware", "/nodes/{}".format(node.node_id))
         self.node = node
         self._warn = warn
         self._error = error

--- a/Jumpscale/sal_zos/healthchecks/cpu_mem_core.py
+++ b/Jumpscale/sal_zos/healthchecks/cpu_mem_core.py
@@ -14,7 +14,7 @@ Result will be shown in the "System Load" section of the Grid Portal / Status Ov
 
 class Memory(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("memory", "Memory", "System Load", resource)
         self.node = node
 
@@ -37,7 +37,7 @@ class Memory(HealthCheckRun):
 
 class CPU(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("CPU", "CPU", "System Load", resource)
         self.node = node
 

--- a/Jumpscale/sal_zos/healthchecks/diskusage.py
+++ b/Jumpscale/sal_zos/healthchecks/diskusage.py
@@ -10,7 +10,7 @@ Monitors if disk usage is too high
 
 class DiskUsage(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("disk-usage", "Disk Usage Check", "Hardware", resource)
         self.node = node
 

--- a/Jumpscale/sal_zos/healthchecks/fan.py
+++ b/Jumpscale/sal_zos/healthchecks/fan.py
@@ -10,7 +10,7 @@ Result will be shown in the "Hardware" section of the Grid Portal / Status Overv
 class Fan(IPMIHealthCheck):
     def __init__(self, node):
         self.node = node
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__(id="fan", name="Fan", category="Hardware", resource=resource)
 
     def run(self, container):

--- a/Jumpscale/sal_zos/healthchecks/interrupts.py
+++ b/Jumpscale/sal_zos/healthchecks/interrupts.py
@@ -10,7 +10,7 @@ Monitors if a number of interrupts
 
 class Interrupts(HealthCheckRun):
     def __init__(self, node, warn=180000, error=200000):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("interrupts", "CPU Interrupts", "Hardware", resource)
         self._warn = warn
         self._error = error

--- a/Jumpscale/sal_zos/healthchecks/log_rotator.py
+++ b/Jumpscale/sal_zos/healthchecks/log_rotator.py
@@ -12,7 +12,7 @@ Rotate know log files if their size hit 10G or more
 
 class RotateLogs(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("log-rotator", "Log Rotator", "System Load", resource)
         self.node = node
 

--- a/Jumpscale/sal_zos/healthchecks/networkbond.py
+++ b/Jumpscale/sal_zos/healthchecks/networkbond.py
@@ -10,12 +10,12 @@ Monitors if a network bond (if there is one) has both (or more) interfaces prope
 
 class NetworkBond(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("network-bond", "Network Bond Check", "Hardware", resource)
         self.node = node
 
     def run(self):
-        ovs = "{}_ovs".format(self.node.name)
+        ovs = "{}_ovs".format(self.node.node_id)
         try:
             container = self.node.containers.get(ovs)
         except LookupError:

--- a/Jumpscale/sal_zos/healthchecks/networkload.py
+++ b/Jumpscale/sal_zos/healthchecks/networkload.py
@@ -9,7 +9,7 @@ Check the bandwith consumption of the network
 class NetworkLoad(HealthCheckRun):
     def __init__(self, node):
         self.node = node
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__(id="network-load", name="Network Load Check", category="Hardware", resource=resource)
 
     def run(self):

--- a/Jumpscale/sal_zos/healthchecks/openfiledescriptors.py
+++ b/Jumpscale/sal_zos/healthchecks/openfiledescriptors.py
@@ -11,7 +11,7 @@ if it exceeds 90% of the hard limit, it raises an error.
 
 class OpenFileDescriptor(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("openfile-descriptors", "Open File Descriptors", "System Load", resource)
         self.node = node
 

--- a/Jumpscale/sal_zos/healthchecks/powersupply.py
+++ b/Jumpscale/sal_zos/healthchecks/powersupply.py
@@ -9,7 +9,7 @@ Result will be shown in the "Hardware" section of the Grid Portal / Status Overv
 
 class PowerSupply(IPMIHealthCheck):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__(id="pw-supply", name="Power Supply", category="Hardware", resource=resource)
         self.node = node
         self.ps_errmsgs = [

--- a/Jumpscale/sal_zos/healthchecks/qemu_vm_logs.py
+++ b/Jumpscale/sal_zos/healthchecks/qemu_vm_logs.py
@@ -12,7 +12,7 @@ Check on vm logs for errors.
 
 class QemuVMLogs(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("qemu-vm-logs", "Qemu VM Logs", "Qemu Logs", resource)
         self.node = node
 

--- a/Jumpscale/sal_zos/healthchecks/ssh_cleanup.py
+++ b/Jumpscale/sal_zos/healthchecks/ssh_cleanup.py
@@ -10,7 +10,7 @@ Clean up ssh deamons and tcp services from migration
 
 class SSHCleanup(HealthCheckRun):
     def __init__(self, node, service):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("ssh-cleanup", "SSH Cleanup", "System Cleanup", resource)
         self.node = node
 

--- a/Jumpscale/sal_zos/healthchecks/temperature.py
+++ b/Jumpscale/sal_zos/healthchecks/temperature.py
@@ -13,7 +13,7 @@ class Temperature(IPMIHealthCheck):
 
     def __init__(self, node):
         self.node = node
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__("temperature", "Node Temperature Check", "Hardware", resource)
 
     def run(self, container):

--- a/Jumpscale/sal_zos/healthchecks/threads.py
+++ b/Jumpscale/sal_zos/healthchecks/threads.py
@@ -8,7 +8,7 @@ Monitors if threads has high number of threads per hyperthread
 
 class Threads(HealthCheckRun):
     def __init__(self, node):
-        resource = "/nodes/{}".format(node.name)
+        resource = "/nodes/{}".format(node.node_id)
         super().__init__(id="threads", name="Node thread per hyperthread", category="System Load", resource=resource)
         self.node = node
 

--- a/Jumpscale/sal_zos/node/Node.py
+++ b/Jumpscale/sal_zos/node/Node.py
@@ -35,9 +35,7 @@ class Node:
     def __init__(self, client):
         # g8os client to talk to the node
         self._storage_addr = None
-        self._name = None
-        self.addr = client.host
-        self.port = client.port
+        self._node_id = None
         self.disks = Disks(self)
         self.storagepools = StoragePools(self)
         self.containers = Containers(self)
@@ -50,18 +48,26 @@ class Node:
         self.capacity = Capacity(self)
         self.client = client
 
+    @property
+    def addr(self):
+        return self.client.host
+
+    @property
+    def port(self):
+        return self.client.port
+
     def ping(self):
         return self.client.ping()
 
     @property
-    def name(self):
-        if self._name is None:
+    def node_id(self):
+        if self._node_id is None:
             nics = self.client.info.nic()
             macgwdev, _ = self.get_nic_hwaddr_and_ip(nics)
             if not macgwdev:
                 raise AttributeError("name not found for node {}".format(self))
-            self._name = macgwdev.replace(":", "")
-        return self._name
+            self._node_id = macgwdev.replace(":", "")
+        return self._node_id
 
     @property
     def kernel_args(self):
@@ -204,7 +210,7 @@ class Node:
 
             # include devices which have partitions
             if len(disk.partitions) == 0:
-                available_disks.setdefault(self.name, []).append(disk)
+                available_disks.setdefault(self.node_id, []).append(disk)
 
         return available_disks
 

--- a/Jumpscale/sal_zos/stats_collector/stats_collector.py
+++ b/Jumpscale/sal_zos/stats_collector/stats_collector.py
@@ -11,7 +11,7 @@ class StatsCollector:
         self.db = db
         self.retention = retention
         self.jwt = jwt
-        self.job_id = "stats_collector.{}".format(self.container.node.name)
+        self.job_id = "stats_collector.{}".format(self.container.node.node_id)
 
     def get_command(self):
         cmd = ["0-statscollector"]


### PR DESCRIPTION
fixes #575

## Description

`name` is a reserved key work by the config manager, client class cannot use it.