### PR TITLE
markdowndocs: write docsite metadata to as json

### DIFF
--- a/Jumpscale/tools/markdowndocs/DocSite.py
+++ b/Jumpscale/tools/markdowndocs/DocSite.py
@@ -591,6 +591,19 @@ class DocSite(j.application.JSBaseClass):
 
     __str__ = __repr__
 
+    def write_metadata(self, dest):
+        # Create file with extra content to be loaded in docsites
+        data = {
+            'name': self.name,
+            'repo': ''
+        }
+
+        if self.git:
+            data['repo'] = "https://github.com/%s/%s" % (self.account, self.repo)
+
+        data_json = j.data.serializers.json.dumps(data)
+        j.sal.fs.writeFile(filename=dest + "/.data", contents=data_json, append=False)
+
     def write(self, reset=False):
         self.load()
         self.verify()
@@ -610,10 +623,8 @@ class DocSite(j.application.JSBaseClass):
         # j.sal.fs.copyDirTree(self.path, self.outpath, overwriteFiles=True, ignoredir=['.*'], ignorefiles=[
         #               "*.md", "*.toml", "_*", "*.yaml", ".*"], rsync=True, recursive=True, rsyncdelete=True)
 
-        # Create file with extra content to be loaded in docsites
-        if self.account and self.repo:
-            repo_info = "https://github.com/%s/%s" % (self.account, self.repo)
-            j.sal.fs.writeFile(filename=dest + "/.data", contents=repo_info, append=False)
+
+        self.write_metadata(dest)
 
         keys = [item for item in self.docs.keys()]
         keys.sort()


### PR DESCRIPTION
Write metadata of docsite in json.

## Description

Summary of the changes.

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.