### PR TITLE
fix(installer) force noninteractive for apt upgrade

### DIFF
--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -3290,7 +3290,10 @@ class DockerContainer:
             self.dexec("rm -f /etc/service/sshd/down")
             if baseinstall:
                 print(" - Upgrade ubuntu")
-                self.dexec("apt update; apt upgrade -y; apt install mc git -y")
+                self.dexec("apt update")
+                self.dexec("DEBIAN_FRONTEND=noninteractive apt-get -y upgrade")
+                print(" - Upgrade ubuntu ended") 
+                self.dexec("apt install mc git -y")
 
             Tools.execute("rm -f ~/.ssh/known_hosts")  # dirty hack
 


### PR DESCRIPTION
this fixes #619.
Install script hangs forever after apt upgrade.
Apt upgrade causes libssl to prompt for services restart in a non interactive bash session.