### PR TITLE
feat basic http auth

### DIFF
--- a/Jumpscale/builder/apps/BuilderCoreX.py
+++ b/Jumpscale/builder/apps/BuilderCoreX.py
@@ -132,7 +132,7 @@ class BuilderCoreX(j.builders.system._BaseClass):
         assert len(cc.process_list()) == 1
 
         self.stop()
-        assert self.running() == False
+        assert self.running() is False
         print("TEST OK")
 
     @builder_method()

--- a/Jumpscale/builder/apps/BuilderCoreX.py
+++ b/Jumpscale/builder/apps/BuilderCoreX.py
@@ -115,11 +115,7 @@ class BuilderCoreX(j.builders.system._BaseClass):
     def stop(self):
         # killing the daemon
         pane = j.tools.tmux.pane_get(self.NAME)
-        processes = pane.process_obj.children(True)
-        for process in processes:
-            process.kill()
         pane.kill()
-        """ j.sal.process.killProcessByName(self.NAME) """
 
     @builder_method()
     def test(self):
@@ -127,16 +123,16 @@ class BuilderCoreX(j.builders.system._BaseClass):
             self.stop()
 
         self.start()
-        cc = j.clients.corex.get("localhost", 7681)
+        cc = j.clients.corex.get(addr="localhost", port=7681)
         assert cc.process_list() == []
 
-        cc.process_start("/bin/true")
+        cc.process_start("true", "/bin/true")
 
-        cc = j.clients.corex.get("localhost", 7681)
+        cc = j.clients.corex.get(addr="localhost", port=7681)
         assert len(cc.process_list()) == 1
 
         self.stop()
-
+        assert self.running() == False
         print("TEST OK")
 
     @builder_method()

--- a/Jumpscale/clients/corex/CoreXClient.py
+++ b/Jumpscale/clients/corex/CoreXClient.py
@@ -34,10 +34,8 @@ class CoreXClient(j.application.JSBaseConfigClass):
 
         try:
             url = "%s/%s" % (self._service_url, base_url)
-            print("***********************login:%s pass:%s" % (self.login, self.passwd_))
             if self.login != "":
                 response = requests.get(url, auth=(self.login, self.passwd_), params=params)
-                print("res:%s" % response)
             else:
                 response = requests.get(url, params=params)
             # response = requests.request(**request_conf)

--- a/Jumpscale/clients/corex/CoreXFactory.py
+++ b/Jumpscale/clients/corex/CoreXFactory.py
@@ -26,14 +26,14 @@ class CoreXClientFactory(j.application.JSBaseConfigsClass):
             if passw:
                 port = 8002
                 cmd = "/sandbox/bin/corex --port {} -c user:pass".format(port)
+                cl = self.get(name="test", addr="localhost", port=port, login="user", passwd_="pass")
             else:
                 port = 8002
                 cmd = "/sandbox/bin/corex --port {}".format(port)
+                cl = self.get(name="test", addr="localhost", port=port)
 
             cmd0 = j.tools.startupcmd.get(name="corex_%s" % port, cmd=cmd, ports=[port])
             cmd0.start(reset=True)
-
-            cl = self.get(name="test", addr="localhost", port=port)
 
             assert cl.process_list() == []
 
@@ -78,5 +78,8 @@ class CoreXClientFactory(j.application.JSBaseConfigsClass):
             j.clients.corex.reset()
             # j.shell()
 
+        print("TEST NO AUTH")
         test(False)
-        # test(True)
+        print("TEST WITH AUTH")
+        test(True)
+        print("ALL TEST OK")


### PR DESCRIPTION
Resolves: https://github.com/threefoldtech/jumpscaleX/issues/614
Resolves: https://github.com/threefoldtech/jumpscaleX/issues/613

## Description
corex client and builder test passes (even if you play them twice)
corex client support corex basic authentication
process_kill method added to corex client process 

did try to generate CA cert to enable ssl by default but it seems that on zos there is no random source
 
## Checklists
 - corex builder clean `j.builders.apps.corex.clean()` build ` j.builders.apps.corex.build()` and install `j.builders.apps.corex.install()`
 - corex builder run test ` j.builders.apps.corex.test()`
 - corex client run test twice `j.clients.corex.test()`

 
