### PR TITLE
[doc] Development installer doc reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,27 +38,9 @@ Some tools available in jumpscale
   Builder tools is a set of tools to perform the common tasks in your builder (e.g read a file , write to a file, execute bash commands and many other handy methods that you will probably need in your builder) \
   To create a builder see [documentation](docs/howto/Create\ a\ new\ Builder.md)
 
-# Getting Started
+## Install and use Jumpscale
 
-Get up to speed by following these [simple steps](/docs/Installation/get_started.md).
-
-## Installing Jumpscale
-
-[See documentation](/docs/Installation)
-
-
-
-## Usage
-
-* Kosmos in your terminal, type `kosmos`
-
-* In Python
-
-  ```bash
-  python3 -c 'from Jumpscale import j;print(j.application.getMemoryUsage())'
-  ```
-
-  the default mem usage < 23 MB and lazy loading of the modules.
+[See installation doc](/docs/Installation)
 
 ## Running Tests
 To run unittests you can execute the following command

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some tools available in jumpscale
 
 ## Install and use Jumpscale
 
-[See installation doc](/docs/Installation)
+[See installation doc](/docs/Installation/README.md)
 
 ## Running Tests
 To run unittests you can execute the following command

--- a/docs/Installation/README.md
+++ b/docs/Installation/README.md
@@ -1,38 +1,69 @@
 # Installation Instructions Jumpscale X
 
+## Prerequisites
+
+Before starting the installation to make sure to install the [prerequisites](/docs/Installation/install_prerequisites.md).
+
+## Install Jumpscale X using docker
 
 ```bash
-#get the installer
-curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development/install/jsx.py?$RANDOM > /tmp/jsx
-chmod 777 /tmp/jsx
-#install
+# TODO CHANGE BRANCH WITH MASTER (replace development_installer)
+# get the jsx command (installer)
+curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development_installer/install/jsx.py?$RANDOM > /tmp/jsx ; \
+chmod +x /tmp/jsx; \
+# install
 /tmp/jsx container-install
-#get first time your kosmos shell
+```
+
+The installer will ask you to provide a secret (and a couple of yes/no questions to which you answer yes).
+If successfull, you will see something like:
+
+```bash
+install succesfull:
+# if you use a container do:
+jsx container-kosmos
+
+```
+
+The install script has built and started a docker container named `3bot` on your machine.
+
+## To use Jumpscale X
+
+To start JumpcaleX:
+
+```bash
+# get your kosmos shell (inside your 3bot container)
 /tmp/jsx container-kosmos
+```
+
+Once kosmos is launched you will see this line:
+
+```bash
+JSX>
+```
+
+Congrats ! You may now use this jsx shell to manipulate the Jumpscale X library ! Follow these [steps](Installation/get_started.md) to go further in the use of Jumpscale.
+
+If jsx is missing from your `/tmp` folder:
+
+```bash
+# get the jsx command
+curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development_installer/install/jsx.py?$RANDOM > /tmp/jsx ; \
+chmod +x /tmp/jsx; \
+# get your kosmos shell (inside your 3bot container)
+/tmp/jsx container-kosmos
+```
+
+## jsx command help
+
+```bash
 #get more help of jsx command
 /tmp/jsx --help
 ```
 
-before you can do this you need to make sure that docker has been installed on your system.
-
-## To use
-
-```bash
-#to get container kosmos shell (JSX)
-python3 /tmp/jsx.py container-kosmos
-#to get shell of the ubuntu base os underneath in the container
-python3 /tmp/jsx.py container-shell
-```
-
 ## OSX requirements
 
-```bash
-#to install brew:
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
-# install requirements
-brew install curl python3 git rsync
-```
+[see here OSX requirements specifics](/docs/Installation/install_prerequisites.md#osx)
 
 ## JSX
 

--- a/docs/Installation/get_started.md
+++ b/docs/Installation/get_started.md
@@ -1,24 +1,72 @@
-# Get Started
-## Prerequisite
+# Getting Started
+
+## Installation prerequisites
+
 * Mac OS X 10.7 (Lion) or newer or a linux OS (tested on ubuntu 18.04)
 * Git installed with a github account
 * an ssh key added to github
-    * go [here](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to generate a ssh key
-    * go [here](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account) to add a ssh key to your github account
-    * to list your public ssh keys `ssh-add -L`
+  * go [here](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to generate a ssh key
+  * go [here](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account) to add a ssh key to your github account
+  * to list your public ssh keys `ssh-add -L`
 * Docker
-    * installation [guide](https://docs.docker.com/v17.12/install/#server)
+  * installation [guide](https://docs.docker.com/v17.12/install/#server)
     * verify installation with `$docker --version`
 * Python3
-
-    * installation [guide](https://www.python.org/downloads/)
+  * installation [guide](https://www.python.org/downloads/)
     * verify installation with `$python3 --version`
 * pip3  
-    * `$sudo apt install python3-pip`
+  * `$sudo apt install python3-pip`
 * click python package  
-    *  `$pip3 install click `  
+  * `$pip3 install click`  
+
+## Install Jumpscale X using docker
+
+```bash
+# fetch JSX install script and set up inside container
+# TODO CHANGE BRANCH WITH MASTER
+curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development_installer/install/jsx.py?$RANDOM > /tmp/jsx ; \
+chmod +x /tmp/jsx; \
+/tmp/jsx container-install
+```
+
+The installer will ask you to provide a secret (and a couple of yes/no questions to which you answer yes).
+If successfull, you will see something like:
+
+```bash
+install succesfull:
+# if you use a container do:
+jsx container-kosmos
+
+```
+
+The install script has built and started a docker container named `3bot` on your machine.
+
+## Start Jumpscale X
+
+To start JumpcaleX:
+
+```bash
+/tmp/jsx container-kosmos
+```
+
+Once kosmos is launched you will see this line:
+
+```bash
+JSX>
+```
+Congrats ! You may now use this jsx shell to manipulate the Jumpscale X library !
+
+If jsx is missing from your `/tmp` folder:
+
+```bash
+#fetch JSX and start Jumpscale X inside container
+curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development_installer/install/jsx.py?$RANDOM > /tmp/jsx ; \
+chmod +x /tmp/jsx; \
+/tmp/jsx container-kosmos
+```
 
 ## philosophy
+
 JumpscaleX aka JSX was created at the beginning so that junior system administrators can easily use this tool to manage resources, provision machines, create and deploy containers.
 
 It will evolve even further to be your digital representation that will always be available. Right now this tool works on your machine but soon it will be automatically deployed on the TF grid.
@@ -27,65 +75,6 @@ It will even be able to engage in trade with others and this network of 3bots wi
 
 Don't worry nobody except you can take control over your 3bot as all your config files are encrypted (securely stored) and your keys never leaves your device.
 
-# Installation
-
-## Launch a Jumpscale X container
-
-### How it works
-
-The python script will load a docker image and start a docker container on your machine. You just need to answer a few questions during the install script. The container will bind a volume between the directory that holds the JSX code and the container (at /sandbox/code). You will be able to connect securely via ssh to this container and launch the shell (aka kosmos) to manipulate the Jumpscale X library .
-
-### Install scripts
-
-```bash
-#get the installer
-# TODO CHANGE BRANCH WITH MASTER
-curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development_installer/install/jsx.py?$RANDOM > /tmp/jsx.py ; \
-#install
-python3 /tmp/jsx.py container-install; \
-cp /tmp/jsx.py /tmp/jsx; \
-chmod +x /tmp/jsx; \
-```
-
-get more help about the jsx command
-```bash
-/tmp/jsx --help
-```
-
-### shortcut to jsx
-
-if you want to be able to launch `jsx` directly instead of typing `/tmp/jsx` you should either.
-* add it to  your `$PATH`
-```
-$ PATH=$PATH:/tmp
-```
-* move the `jsx` binary to your `/usr/local/bin`
-```
-$ sudo mv /tmp/jsx /usr/local/bin
-```
-
-## launching kosmos the jumpscale X REPL(read–eval–print loop) shell
-
-you can launch kosmos the easy way with this command
-
-```bash
-#get first time your kosmos shell
-$ /tmp/jsx container-kosmos;
-```
-
-or by connecting to your container through ssh
-
-```bash
-# to login to the docker using ssh use (if std port)
-$ ssh root@localhost -A -p 9122
-root@3bot:~$ source /sandbox/env.sh; kosmos;
-```
-
-once kosmos is launched you will see this line
-
-```bash
-JSX>
-```
 
 # 1. Using kosmos to create a wallet on the ThreeFold blockchain aka TFChain
 

--- a/docs/Installation/get_started.md
+++ b/docs/Installation/get_started.md
@@ -1,69 +1,4 @@
-# Getting Started
-
-## Installation prerequisites
-
-* Mac OS X 10.7 (Lion) or newer or a linux OS (tested on ubuntu 18.04)
-* Git installed with a github account
-* an ssh key added to github
-  * go [here](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to generate a ssh key
-  * go [here](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account) to add a ssh key to your github account
-  * to list your public ssh keys `ssh-add -L`
-* Docker
-  * installation [guide](https://docs.docker.com/v17.12/install/#server)
-    * verify installation with `$docker --version`
-* Python3
-  * installation [guide](https://www.python.org/downloads/)
-    * verify installation with `$python3 --version`
-* pip3  
-  * `$sudo apt install python3-pip`
-* click python package  
-  * `$pip3 install click`  
-
-## Install Jumpscale X using docker
-
-```bash
-# fetch JSX install script and set up inside container
-# TODO CHANGE BRANCH WITH MASTER
-curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development_installer/install/jsx.py?$RANDOM > /tmp/jsx ; \
-chmod +x /tmp/jsx; \
-/tmp/jsx container-install
-```
-
-The installer will ask you to provide a secret (and a couple of yes/no questions to which you answer yes).
-If successfull, you will see something like:
-
-```bash
-install succesfull:
-# if you use a container do:
-jsx container-kosmos
-
-```
-
-The install script has built and started a docker container named `3bot` on your machine.
-
-## Start Jumpscale X
-
-To start JumpcaleX:
-
-```bash
-/tmp/jsx container-kosmos
-```
-
-Once kosmos is launched you will see this line:
-
-```bash
-JSX>
-```
-Congrats ! You may now use this jsx shell to manipulate the Jumpscale X library !
-
-If jsx is missing from your `/tmp` folder:
-
-```bash
-#fetch JSX and start Jumpscale X inside container
-curl https://raw.githubusercontent.com/threefoldtech/jumpscaleX/development_installer/install/jsx.py?$RANDOM > /tmp/jsx ; \
-chmod +x /tmp/jsx; \
-/tmp/jsx container-kosmos
-```
+# Using Jumpscale
 
 ## philosophy
 
@@ -74,7 +9,6 @@ This 3bot, as we call it, will make sure your applications are properly running 
 It will even be able to engage in trade with others and this network of 3bots will act as a decentalized exchange.
 
 Don't worry nobody except you can take control over your 3bot as all your config files are encrypted (securely stored) and your keys never leaves your device.
-
 
 # 1. Using kosmos to create a wallet on the ThreeFold blockchain aka TFChain
 

--- a/docs/Installation/install_insystem.md
+++ b/docs/Installation/install_insystem.md
@@ -59,3 +59,15 @@ python3 /tmp/jsx.py install
 ```bash
 source /sandbox/env.sh; kosmos
 ```
+
+## Usage
+
+* Kosmos in your terminal, type `kosmos`
+
+* In Python
+
+  ```bash
+  python3 -c 'from Jumpscale import j;print(j.application.getMemoryUsage())'
+  ```
+
+  the default mem usage < 23 MB and lazy loading of the modules.

--- a/docs/Installation/install_prerequisites.md
+++ b/docs/Installation/install_prerequisites.md
@@ -1,0 +1,43 @@
+# Jumpscale Installation Prerequisites
+
+Prior to installing Jumpscale you need the following elements:
+
+* Mac OS X 10.7 (Lion) or newer or a linux OS (tested on ubuntu 18.04)
+* Git installed with a github account
+* an ssh key added to github
+  * go [here](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) to generate a ssh key
+  * go [here](https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account) to add a ssh key to your github account
+  * to list your public ssh keys `ssh-add -L`
+* Curl
+* Docker
+  * installation [guide](https://docs.docker.com/v17.12/install/#server)
+    * verify installation with `$docker --version`
+* Python3
+  * installation [guide](https://www.python.org/downloads/)
+    * verify installation with `$python3 --version`
+* pip3  
+  * `$sudo apt install python3-pip`
+* click python package  
+  * `$pip3 install click`
+
+<a name="osx"></a>
+## OSX specifics
+On OSX you probably want to install [homebrew](https://brew.sh), the package manager for macOS.
+
+```bash
+#to install brew:
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+# install requirements
+brew install curl python3 git rsync
+```
+
+### Install docker for mac osx
+[see docker-for-mac dmg install](https://docs.docker.com/v17.12/docker-for-mac/install/#download-docker-for-mac)
+
+## Next
+
+Once the requirements here above are satisfied, you may start installing Jumpscale.
+
+[See installation doc](/docs/Installation/README.md)
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,10 @@
 
 [Jumpscale](http://www.jumpscale.com/) is an extensible and easy to use cloud and IT automation solution, providing a huge library that supports executing a wide range of system operations. [Jumpscale](http://www.jumpscale.com/) is the evolution of Pylabs which was the basic building block for cloud automation originally developed by [Q-Layer](https://incubaid.com/q-layer.html), and acquired by Sun Microsystems in 2009\. The current release of Jumpscale is version 10 called JSX.
 
+## Install and use Jumpscale
 
-# Get Started
-
-Get up to speed by following these [simple steps](Installation/get_started.md).
+- [See installation doc](/docs/Installation)
+- Get up to speed by following these [steps](Installation/get_started.md).
 
 
 ## Help us improve Jumpscale


### PR DESCRIPTION
See: #598

## Description

Reorganize installation doc and navigation between readme.md. 
Update installation prerequisites for ubuntu and OsX (docker, ssh-key, click...).