### PR TITLE
markdowndocs: allow svg images

### DIFF
--- a/Jumpscale/tools/markdowndocs/DocSite.py
+++ b/Jumpscale/tools/markdowndocs/DocSite.py
@@ -303,6 +303,7 @@ class DocSite(j.application.JSBaseClass):
             "js",
             "mov",
             "py",
+            "svg",
         ]:
             self._log_debug("found file:%s" % path)
             base = self._clean(base)

--- a/Jumpscale/tools/markdowndocs/Link.py
+++ b/Jumpscale/tools/markdowndocs/Link.py
@@ -387,7 +387,7 @@ class Link(j.application.JSBaseClass):
             # only possible for images (video, image)
             if self.source.startswith("!"):
                 self.cat = "image"
-                if not self.extension in ["png", "jpg", "jpeg", "mov", "mp4"]:
+                if not self.extension in ["png", "jpg", "jpeg", "mov", "mp4", "svg"]:
                     return self.error("found unsupported image file: extension:%s" % self.extension)
 
             if self.cat == "":


### PR DESCRIPTION

## Description

Add svg to supported images in mardowndocs tool.

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.