### PR TITLE
MyEnv has no attribute config on development

### DIFF
--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -2120,6 +2120,12 @@ class MyEnv:
         :param sshagent_use: needs to be True if sshkey used
         :return:
         """
+
+        if not os.path.exists(MyEnv.config_file_path):
+            MyEnv.config = MyEnv.config_default_get(config=config)
+        else:
+            MyEnv._config_load()
+
         if interactive not in [True, False]:
             raise RuntimeError("interactive is True or False")
         MyEnv.interactive = interactive
@@ -2190,11 +2196,6 @@ class MyEnv:
 
         if codedir is not None:
             config["DIR_CODE"] = codedir
-
-        if not os.path.exists(MyEnv.config_file_path):
-            MyEnv.config = MyEnv.config_default_get(config=config)
-        else:
-            MyEnv._config_load()
 
         if not "DIR_TEMP" in MyEnv.config:
             config.update(MyEnv.config)

--- a/install/jsx.py
+++ b/install/jsx.py
@@ -523,7 +523,7 @@ def check():
 
 def _generate(path=None):
     j = jumpscale_get(die=True)
-    j.application.generate()
+    j.application.generate(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves: https://github.com/threefoldtech/jumpscaleX/issues/602

## Description
fix type object 'MyEnv' has no attribute 'config' for installer on developemt
that was caused by calling config before setting it
