### PR TITLE
fix kosmos start (needs wsgidav)

### DIFF
--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -2642,6 +2642,7 @@ class BaseInstaller:
                 "pbkdf2",
                 "ptpython",
                 "pygments-markdown-lexer",
+                "wsgidav",
             ],
             # level 1: in the middle
             1: [


### PR DESCRIPTION
bcdb webdav support needs wsgidav.  (fix after 6a2d86e37d1bb33ef14f412c1cfcca4fa9303538)

Resolves: #673
