### PR TITLE
shell: always redirect logs to pane when getting auto-completions

### DIFF
--- a/Jumpscale/core/BASECLASSES/JSBase.py
+++ b/Jumpscale/core/BASECLASSES/JSBase.py
@@ -380,9 +380,6 @@ class JSBase:
 
         """
 
-        if j.application._in_autocomplete:
-            return None
-
         if j.application.debug or self.__class__._logger_min_level - 1 < level:
             # now we will log
 
@@ -427,6 +424,8 @@ class JSBase:
                     logdict["context"] = ""
                     pass  # TODO:*1 is not good
             logdict["cat"] = cat
+
+            logdict["use_custom_printer"] = j.application._in_autocomplete
 
             logdict["data"] = data
             if data and isinstance(data, dict):

--- a/Jumpscale/tools/logger/LoggerFactory.py
+++ b/Jumpscale/tools/logger/LoggerFactory.py
@@ -9,15 +9,13 @@ class LoggerFactory(j.application.JSBaseClass):
 
     @property
     def debug(self):
-        if "LOGGER_SHELL_LOWERPANE" not in j.core.myenv.config:
-            return False
-        return j.core.myenv.config["LOGGER_SHELL_LOWERPANE"]
+        return j.core.myenv.config["DEBUG"]
 
     @debug.setter
     def debug(self, value):
         assert j.data.types.bool.check(value)
         config = {}
-        config["LOGGER_SHELL_LOWERPANE"] = value
+        config["DEBUG"] = value
         self.config = config
 
     @property

--- a/cmds/kosmos
+++ b/cmds/kosmos
@@ -48,9 +48,6 @@ if options.debug:
     j.tools.logger.reload()
     j.tools.logger.debug = True
 
-# lets for now put it on all the time
-j.tools.logger.debug = True
-
 
 def instruction_process(ddict):
 

--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -822,7 +822,7 @@ class Tools:
             script = """
             pip3 install ipython==7.5.0 ptpython==2.0.4 prompt-toolkit==2.0.9 --force-reinstall
             pip3 install pudb
-            pip3 install pygments            
+            pip3 install pygments
             """
             Tools.execute(script, interactive=True)
 
@@ -1082,8 +1082,10 @@ class Tools:
             logdict["context"] = ""
 
         p = print
-        if MyEnv.config["DEBUG"] and MyEnv.config.get("log_printer"):
-            p = MyEnv.config["log_printer"]
+        if MyEnv.config["DEBUG"] or logdict.get('use_custom_printer'):
+            custom_printer = MyEnv.config.get("log_printer")
+            if custom_printer:
+                p = custom_printer
 
         msg = Tools.text_replace(LOGFORMAT, args=logdict, ignore_error=True)
         msg = Tools.text_replace(msg, args=logdict, ignore_error=True)
@@ -3217,7 +3219,7 @@ class DockerContainer:
                 self.config.save()
         if "SSH_Agent" in MyEnv.config and MyEnv.config["SSH_Agent"]:
             MyEnv.sshagent.key_default  # means we will load ssh-agent and help user to load it properly
-        
+
         if len(MyEnv.sshagent.keys_list()) == 0:
             raise RuntimeError("Please load your ssh-agent with a key!")
 


### PR DESCRIPTION
Resolves: #688.

## Description

Always redirect logs to lower pane if we are in auto-completion, this way, we won't lose the logs and they can be shown by setting `j.tools.logger.debug` to `True` (this will be helpful in case for example we cannot get any errors while trying to get auto-completions).

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.