### PR TITLE
shell: make logging panel line count configurable

### DIFF
--- a/Jumpscale/core/KosmosShell.py
+++ b/Jumpscale/core/KosmosShell.py
@@ -223,7 +223,7 @@ class FormatANSIText(Processor):
 class HasLogs(PythonInputFilter):
     def __call__(self):
         j = KosmosShellConfig.j
-        panel_enabled = bool(j.core.myenv.config.get("logging_panel_lines", -1))
+        panel_enabled = bool(j.core.myenv.config.get("LOGGER_PANEL_NRLINES", -1))
         in_autocomplete = j.application._in_autocomplete
         return len(LogPane.Buffer.text) > 0 and LogPane.Show and panel_enabled and not in_autocomplete
 
@@ -270,7 +270,7 @@ def add_logs_to_pane(msg):
 def setup_logging_containers(repl):
     j = KosmosShellConfig.j
 
-    panel_line_count = j.core.myenv.config.get("logging_panel_lines", -1)
+    panel_line_count = j.core.myenv.config.get("LOGGER_PANEL_NRLINES", -1)
     auto = panel_line_count < 0
     if auto:
         panel_line_count = 12  # default

--- a/Jumpscale/core/KosmosShell.py
+++ b/Jumpscale/core/KosmosShell.py
@@ -223,9 +223,9 @@ class FormatANSIText(Processor):
 class HasLogs(PythonInputFilter):
     def __call__(self):
         j = KosmosShellConfig.j
-        debug = j.core.myenv.config.get("DEBUG", False)
+        panel_enabled = bool(j.core.myenv.config.get("logging_panel_lines", -1))
         in_autocomplete = j.application._in_autocomplete
-        return len(LogPane.Buffer.text) > 0 and LogPane.Show and debug and not in_autocomplete
+        return len(LogPane.Buffer.text) > 0 and LogPane.Show and panel_enabled and not in_autocomplete
 
 
 class IsInsideString(PythonInputFilter):
@@ -268,6 +268,13 @@ def add_logs_to_pane(msg):
 
 
 def setup_logging_containers(repl):
+    j = KosmosShellConfig.j
+
+    panel_line_count = j.core.myenv.config.get("logging_panel_lines", -1)
+    auto = panel_line_count < 0
+    if auto:
+        panel_line_count = 12  # default
+
     parent_container = get_ptpython_parent_container(repl)
     parent_container.children.extend(
         [
@@ -284,12 +291,16 @@ def setup_logging_containers(repl):
                         preview_search=True,
                     ),
                     wrap_lines=True,
-                    height=Dimension(max=12),
+                    height=Dimension(max=panel_line_count),
                 ),
                 filter=HasLogs(repl) & ~is_done,
             ),
         ]
     )
+
+    if not auto:
+        for _ in range(panel_line_count):
+            add_logs_to_pane("")
 
 
 def ptconfig(repl):

--- a/cmds/kosmos
+++ b/cmds/kosmos
@@ -40,7 +40,7 @@ parser.add_argument(
 
 parser.add_argument("--debug", default=False, action="store_true", help="will go in debug session when error")
 parser.add_argument(
-    "--logging_panel_lines",
+    "--logging-panel-lines",
     type=int,
     default=-1,
     help="set the line count for logging panel (0 means disabled), default: -1 (auto)",
@@ -63,7 +63,7 @@ if options.debug:
     j.tools.logger.debug = True
 
 
-j.core.myenv.config["logging_panel_lines"] = options.logging_panel_lines
+j.core.myenv.config["LOGGER_PANEL_NRLINES"] = options.logging_panel_lines
 
 
 def instruction_process(ddict):

--- a/cmds/kosmos
+++ b/cmds/kosmos
@@ -39,6 +39,12 @@ parser.add_argument(
 )
 
 parser.add_argument("--debug", default=False, action="store_true", help="will go in debug session when error")
+parser.add_argument(
+    "--logging_panel_lines",
+    type=int,
+    default=-1,
+    help="set the line count for logging panel (0 means disabled), default: -1 (auto)",
+)
 
 
 options, args = parser.parse_known_args()
@@ -55,6 +61,9 @@ if options.debug:
     j.core.myenv.config["LOGGER_INCLUDE"] = ["*"]
     j.tools.logger.reload()
     j.tools.logger.debug = True
+
+
+j.core.myenv.config["logging_panel_lines"] = options.logging_panel_lines
 
 
 def instruction_process(ddict):

--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -1089,7 +1089,7 @@ class Tools:
             logdict["context"] = ""
 
         p = print
-        if MyEnv.config["logging_panel_lines"] or logdict.get("use_custom_printer"):
+        if MyEnv.config["LOGGER_PANEL_NRLINES"] or logdict.get("use_custom_printer"):
             custom_printer = MyEnv.config.get("log_printer")
             if custom_printer:
                 p = custom_printer

--- a/install/InstallTools.py
+++ b/install/InstallTools.py
@@ -1089,7 +1089,7 @@ class Tools:
             logdict["context"] = ""
 
         p = print
-        if MyEnv.config["DEBUG"] or logdict.get("use_custom_printer"):
+        if MyEnv.config["logging_panel_lines"] or logdict.get("use_custom_printer"):
             custom_printer = MyEnv.config.get("log_printer")
             if custom_printer:
                 p = custom_printer
@@ -2922,7 +2922,7 @@ class UbuntuInstaller:
 
         script = """
         cd /tmp
-        apt-get install -y mc wget python3 git tmux 
+        apt-get install -y mc wget python3 git tmux
         set +ex
         apt-get install python3-distutils -y
         set -ex


### PR DESCRIPTION
## Description

Configure logging panel (with visible line count) instead of `DEBUG` flag.

By default, 12 lines are visible (with auto mode), if `--logging_panel_lines` are set, it will force the visibility of lines count given.

Examples:

- `kosmos` will start with auto mode (12 lines visible if any log is available)
- `kosmos --logging-panel-lines 20` will force the visibility of logging panel with 20 lines.
- `kosmos --logging-panel-lines 0` will disable the logging panel.

## Checklists

### Before asking for approval

- [ ] Make sure the changes are covered by tests.
- [ ] All the CI tasks are green.
- [ ] Ensure the branch is up to date with its base branch.
- [ ] Corresponding changes to the documentation were made.